### PR TITLE
64 relocate nf work log outputs in test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 efi.cfg
 efi.config
 tests/test_data/
+tests/test_results/
+.nextflow/
 tests/test.config
 tests/testEnvironment.sh
 *.bak

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/__pycache__
 efi.cfg
 efi.config
+tests/test_data/
 tests/test.config
 tests/testEnvironment.sh
 *.bak

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: docs build-pyEFI build-docker
 
-clean: docs-clean
+clean: docs-clean tests-clean
 
 build-pyEFI:
 	python -m build lib/pyEFI
@@ -35,4 +35,9 @@ test-pipelines:
 
 test-pyefi:
 	pytest lib/pyEFI
+
+tests-clean:
+	rm -rf /tmp/nextflow/efi_tests/
+	rm -rf .nextflow/
+	rm -rf tests/test_data/
 

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,6 @@ test-pyefi:
 
 tests-clean:
 	rm -rf .nextflow/
+	rm -rf tests/test_results/
+	rm -rf tests/test_data/
 

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,4 @@ test-pyefi:
 tests-clean:
 	rm -rf .nextflow/
 	rm -rf tests/test_results/
-	rm -rf tests/test_data/
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,5 @@ test-pyefi:
 	pytest lib/pyEFI
 
 tests-clean:
-	rm -rf /tmp/nextflow/efi_tests/
 	rm -rf .nextflow/
 

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,4 @@ test-pyefi:
 tests-clean:
 	rm -rf /tmp/nextflow/efi_tests/
 	rm -rf .nextflow/
-	rm -rf tests/test_data/
 

--- a/tests/modules/01_est_sequence_blast.sh
+++ b/tests/modules/01_est_sequence_blast.sh
@@ -6,10 +6,14 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
-./bin/create_est_nextflow_params.py blast --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
+OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_sequence_blast"
 
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config smalldata/efi.config --efi-db smalldata/efi_db.sqlite
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
+rm -rf $OUTPUT_DIR
+
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ
+nextflow -log $OUTPUT_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml -w $OUTPUT_DIR/est_work
+
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config smalldata/efi.config --efi-db smalldata/efi_db.sqlite
+nextflow -log $OUTPUT_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml -w $OUTPUT_DIR/generatessn_work
 

--- a/tests/modules/01_est_sequence_blast.sh
+++ b/tests/modules/01_est_sequence_blast.sh
@@ -7,9 +7,9 @@ NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
 ./bin/create_est_nextflow_params.py blast --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
 # ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config smalldata/efi.config --efi-db smalldata/efi_db.sqlite
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
 

--- a/tests/modules/01_est_sequence_blast.sh
+++ b/tests/modules/01_est_sequence_blast.sh
@@ -6,14 +6,10 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
-OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_sequence_blast"
+./bin/create_est_nextflow_params.py blast --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
 
-rm -rf $OUTPUT_DIR
-
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ
-nextflow -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml
-
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config smalldata/efi.config --efi-db smalldata/efi_db.sqlite
-nextflow -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config smalldata/efi.config --efi-db smalldata/efi_db.sqlite
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
 

--- a/tests/modules/02_est_family.sh
+++ b/tests/modules/02_est_family.sh
@@ -6,12 +6,16 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
+OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_family"
+
+rm -rf $OUTPUT_DIR
+
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py family --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot
+nextflow -log $OUTPUT_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml -w $OUTPUT_DIR/est_work
 
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
+nextflow -log $OUTPUT_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml -w $OUTPUT_DIR/generatessn_work
 

--- a/tests/modules/02_est_family.sh
+++ b/tests/modules/02_est_family.sh
@@ -9,9 +9,9 @@ NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 family=$(<$EFI_TEST_FAMILY_ID)
 
 ./bin/create_est_nextflow_params.py family --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
 # ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
 

--- a/tests/modules/02_est_family.sh
+++ b/tests/modules/02_est_family.sh
@@ -6,16 +6,12 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
-OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_family"
-
-rm -rf $OUTPUT_DIR
-
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot
-nextflow -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml
+./bin/create_est_nextflow_params.py family --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
 
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
 

--- a/tests/modules/03_est_fasta.sh
+++ b/tests/modules/03_est_fasta.sh
@@ -6,14 +6,10 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
-OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_fasta"
+./bin/create_est_nextflow_params.py fasta --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
 
-rm -rf $OUTPUT_DIR
-
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE
-nextflow -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml
-
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
 

--- a/tests/modules/03_est_fasta.sh
+++ b/tests/modules/03_est_fasta.sh
@@ -7,9 +7,9 @@ NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
 ./bin/create_est_nextflow_params.py fasta --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
 # ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
 

--- a/tests/modules/03_est_fasta.sh
+++ b/tests/modules/03_est_fasta.sh
@@ -6,10 +6,14 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
-./bin/create_est_nextflow_params.py fasta --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
+OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_fasta"
 
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
+rm -rf $OUTPUT_DIR
+
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE
+nextflow -log $OUTPUT_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml -w $OUTPUT_DIR/est_work
+
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
+nextflow -log $OUTPUT_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml -w $OUTPUT_DIR/generatessn_work
 

--- a/tests/modules/04_est_accession.sh
+++ b/tests/modules/04_est_accession.sh
@@ -7,9 +7,9 @@ NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
 ./bin/create_est_nextflow_params.py accessions --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
 # ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
 

--- a/tests/modules/04_est_accession.sh
+++ b/tests/modules/04_est_accession.sh
@@ -6,14 +6,10 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
-OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_accession"
+./bin/create_est_nextflow_params.py accessions --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE
+nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml
 
-rm -rf $OUTPUT_DIR
-
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE
-nextflow -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml
-
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
+nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml
 

--- a/tests/modules/04_est_accession.sh
+++ b/tests/modules/04_est_accession.sh
@@ -6,10 +6,14 @@ CONFIG_FILE=$2
 NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
 NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
 
-./bin/create_est_nextflow_params.py accessions --output-dir $TEST_RESULTS_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE
-nextflow -log $TEST_RESULTS_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/est_work
+OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_accession"
 
-./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $TEST_RESULTS_DIR
-# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $TEST_RESULTS_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
-nextflow -log $TEST_RESULTS_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $TEST_RESULTS_DIR/ssn/params.yml -w $TEST_RESULTS_DIR/generatessn_work
+rm -rf $OUTPUT_DIR
+
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE
+nextflow -log $OUTPUT_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml -w $OUTPUT_DIR/est_work
+
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR
+# ./bin/create_ssn_nextflow_params.py manual --filter-min-val 87 --ssn-name name --ssn-title title --blast-parquet smalldata/results/1.out.parquet --fasta-file smalldata/results/all_sequences.fasta --output-dir $OUTPUT_DIR/ssn --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
+nextflow -log $OUTPUT_DIR/generatessn_nextflow.log -C $NXF_SSN_CONFIG_FILE run pipelines/generatessn/generatessn.nf -params-file $OUTPUT_DIR/ssn/params.yml -w $OUTPUT_DIR/generatessn_work
 

--- a/tests/modules/05_colorssn_uniprot.sh
+++ b/tests/modules/05_colorssn_uniprot.sh
@@ -15,5 +15,5 @@ fi
 
 ./bin/create_colorssn_nextflow_params.py --final-output-dir $TEST_RESULTS_DIR --ssn-input $ssn_file --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB
 
-nextflow -log $TEST_RESULTS_DIR/colorssn_nextflow.log -C $NXF_COLORSSN_CONFIG_FILE run pipelines/colorssn/colorssn.nf -params-file $TEST_RESULTS_DIR/params.yml
+nextflow -log $TEST_RESULTS_DIR/colorssn_nextflow.log -C $NXF_COLORSSN_CONFIG_FILE run pipelines/colorssn/colorssn.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/colorssn_work
 

--- a/tests/modules/05_colorssn_uniprot.sh
+++ b/tests/modules/05_colorssn_uniprot.sh
@@ -5,10 +5,6 @@ TEST_RESULTS_DIR=$1
 CONFIG_FILE=$2
 NXF_COLORSSN_CONFIG_FILE="conf/colorssn/$CONFIG_FILE"
 
-OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_colorssn_uniprot"
-
-rm -rf $OUTPUT_DIR
-
 ssn_file=$EFI_TEST_SSN_UNIPROT
 if [[ ! -e "$ssn_file" ]]; then
     ssn_file="$TEST_RESULTS_DIR/test_results_accession/ssn/full_ssn.xgmml"
@@ -17,7 +13,7 @@ if [[ ! -e "$ssn_file" ]]; then
     exit 1
 fi
 
-./bin/create_colorssn_nextflow_params.py --final-output-dir $OUTPUT_DIR --ssn-input $ssn_file --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB
+./bin/create_colorssn_nextflow_params.py --final-output-dir $TEST_RESULTS_DIR --ssn-input $ssn_file --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB
 
-nextflow -C $NXF_COLORSSN_CONFIG_FILE run pipelines/colorssn/colorssn.nf -params-file $OUTPUT_DIR/params.yml
+nextflow -log $TEST_RESULTS_DIR/colorssn_nextflow.log -C $NXF_COLORSSN_CONFIG_FILE run pipelines/colorssn/colorssn.nf -params-file $TEST_RESULTS_DIR/params.yml
 

--- a/tests/modules/05_colorssn_uniprot.sh
+++ b/tests/modules/05_colorssn_uniprot.sh
@@ -5,6 +5,10 @@ TEST_RESULTS_DIR=$1
 CONFIG_FILE=$2
 NXF_COLORSSN_CONFIG_FILE="conf/colorssn/$CONFIG_FILE"
 
+OUTPUT_DIR="$TEST_RESULTS_DIR/test_results_colorssn_uniprot"
+
+rm -rf $OUTPUT_DIR
+
 ssn_file=$EFI_TEST_SSN_UNIPROT
 if [[ ! -e "$ssn_file" ]]; then
     ssn_file="$TEST_RESULTS_DIR/test_results_accession/ssn/full_ssn.xgmml"
@@ -13,7 +17,7 @@ if [[ ! -e "$ssn_file" ]]; then
     exit 1
 fi
 
-./bin/create_colorssn_nextflow_params.py --final-output-dir $TEST_RESULTS_DIR --ssn-input $ssn_file --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB
+./bin/create_colorssn_nextflow_params.py --final-output-dir $OUTPUT_DIR --ssn-input $ssn_file --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB
 
-nextflow -log $TEST_RESULTS_DIR/colorssn_nextflow.log -C $NXF_COLORSSN_CONFIG_FILE run pipelines/colorssn/colorssn.nf -params-file $TEST_RESULTS_DIR/params.yml -w $TEST_RESULTS_DIR/colorssn_work
+nextflow -log $OUTPUT_DIR/colorssn_nextflow.log -C $NXF_COLORSSN_CONFIG_FILE run pipelines/colorssn/colorssn.nf -params-file $OUTPUT_DIR/params.yml -w $OUTPUT_DIR/colorssn_work
 

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -23,10 +23,16 @@ fi
 
 echo "Using $CONFIG_FILE config files for processes"
 
-TEST_RESULTS_DIR=test_results
+# if $TEST_RESULTS_DIR not defined already then set to default path
+if [[ -z ${TEST_RESULTS_DIR} ]]; 
+then
+    TEST_RESULTS_DIR=tests/test_results
+fi
+
 if [ ! -d $TEST_RESULTS_DIR ]; then 
     mkdir -p $TEST_RESULTS_DIR
 fi
+echo "Test results will be written in $TEST_RESULTS_DIR"
 
 set +e
 
@@ -49,7 +55,7 @@ fi
 for file in $(ls tests/modules|grep '\.sh$'); do
     echo "================================================================================"
     echo "Executing tests in '$file'"
-    bash "tests/modules/$file" $TEST_RESULTS_DIR $CONFIG_FILE 2> >(tee $TEST_RESULTS_DIR/err.log >&2)
+    bash "tests/modules/$file" $TEST_RESULTS_DIR $CONFIG_FILE
     if [[ $? -eq 0 ]]; then
 	echo "Tests in '$file' passed"
     fi

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -50,7 +50,7 @@ fi
 
 #bash "tests/modules/05_colorssn_uniprot.sh" $TEST_RESULTS_DIR $CONFIG_FILE
 #exit
-for file in $(ls tests/modules|grep \.sh); do
+for file in $(ls tests/modules|grep '\.sh$'); do
     echo "================================================================================"
     echo "Executing tests in '$file'"
     tmp_dir="$(mktemp -d $TEST_RESULTS_DIR/XXXXXX)"

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-# TO DO:
-# add tests for job script creation (issue 63)
-# add tests for results check (no issue yet)
-
 set -e
 
-# def control functions
 function ctrl_c() {
     echo "Stopping all tests"
     exit 0
@@ -55,11 +50,11 @@ for file in $(ls tests/modules|grep '\.sh$'); do
     echo "Executing tests in '$file'"
     tmp_dir="$(mktemp -d $TEST_RESULTS_DIR/XXXXXX)"
     echo "Temporary directories/files will be written in '$tmp_dir'"
-    bash "tests/modules/$file" $tmp_dir $CONFIG_FILE 2> >(tee $tmp_dir/err.log >&2)
+    bash "tests/modules/$file" $tmp_dir $CONFIG_FILE #2> >(tee $tmp_dir/err.log >&2)
     if [[ $? -eq 0 ]]; then
-	echo "Tests in '$file' passed"
-	echo "Cleaning up tmp dir '$tmp_dir'"
-        rm -rf $tmp_dir
+        echo "Tests in '$file' passed"
+        echo "Cleaning up tmp dir '$tmp_dir'"
+        #rm -rf $tmp_dir
     fi
 done;
 

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# def control functions
 function ctrl_c() {
     echo "Stopping all tests"
     exit 0
@@ -22,7 +23,7 @@ fi
 
 echo "Using $CONFIG_FILE config files for processes"
 
-TEST_RESULTS_DIR=/tmp/nextflow/efi_tests
+TEST_RESULTS_DIR=test_results
 if [ ! -d $TEST_RESULTS_DIR ]; then 
     mkdir -p $TEST_RESULTS_DIR
 fi
@@ -48,13 +49,9 @@ fi
 for file in $(ls tests/modules|grep '\.sh$'); do
     echo "================================================================================"
     echo "Executing tests in '$file'"
-    tmp_dir="$(mktemp -d $TEST_RESULTS_DIR/XXXXXX)"
-    echo "Temporary directories/files will be written in '$tmp_dir'"
-    bash "tests/modules/$file" $tmp_dir $CONFIG_FILE #2> >(tee $tmp_dir/err.log >&2)
+    bash "tests/modules/$file" $TEST_RESULTS_DIR $CONFIG_FILE 2> >(tee $TEST_RESULTS_DIR/err.log >&2)
     if [[ $? -eq 0 ]]; then
-        echo "Tests in '$file' passed"
-        echo "Cleaning up tmp dir '$tmp_dir'"
-        #rm -rf $tmp_dir
+	echo "Tests in '$file' passed"
     fi
 done;
 

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
+# TO DO:
+# add tests for job script creation (issue 63)
+# add tests for results check (no issue yet)
+
 set -e
 
+# def control functions
 function ctrl_c() {
     echo "Stopping all tests"
     exit 0
 }
-
 trap ctrl_c SIGINT
-
-TEST_RESULTS_DIR=test_results
 
 # rough test to see if we are in repo root
 if [[ ! -e pipelines/generatessn/generatessn.nf || ! -e pipelines/est/est.nf ]]; then
@@ -25,16 +27,18 @@ fi
 
 echo "Using $CONFIG_FILE config files for processes"
 
-rm -rf $TEST_RESULTS_DIR
-mkdir -p $TEST_RESULTS_DIR
+TEST_RESULTS_DIR=/tmp/nextflow/efi_tests
+if [ ! -d $TEST_RESULTS_DIR ]; then 
+    mkdir -p $TEST_RESULTS_DIR
+fi
 
 set +e
 
 if [[ -z ${EFI_CONFIG_FILE+1} || -z ${EFI_DB_NAME+1} || -z ${EFI_FASTA_DB+1} || -z ${EFI_TEST_ACC_FILE+1} || -z ${EFI_TEST_FASTA_FILE+1} || -z ${EFI_TEST_BLAST_SEQ+1} || -z ${EFI_TEST_ENV+1} || -z ${EFI_TEST_FAMILY_ID+1} ]];
 then
-    echo "Test environment setup not found, please source tests/test_db_env.sh mysql or sqlite"
+    echo "Test environment variables not found, please source tests/test_env.sh mysql or sqlite"
     exit 1
-elif [[ "$EFI_TEST_ENV" != "mysql" && ! -e "$EFI_TEST_DATA_DIR" ]]; then
+elif [[ "$EFI_TEST_ENV" != "mysql" && ! -d "$EFI_TEST_DATA_DIR" ]]; then
     echo "Test data directory not found, attempting to download"
     test_data_dir="tests/test_data/smalldata"
     mkdir -p $test_data_dir
@@ -48,6 +52,14 @@ fi
 #exit
 for file in $(ls tests/modules|grep \.sh); do
     echo "================================================================================"
-    echo "Executing test in '$file'"
-    bash "tests/modules/$file" $TEST_RESULTS_DIR $CONFIG_FILE
+    echo "Executing tests in '$file'"
+    tmp_dir="$(mktemp -d $TEST_RESULTS_DIR/XXXXXX)"
+    echo "Temporary directories/files will be written in '$tmp_dir'"
+    bash "tests/modules/$file" $tmp_dir $CONFIG_FILE 2> >(tee $tmp_dir/err.log >&2)
+    if [[ $? -eq 0 ]]; then
+	echo "Tests in '$file' passed"
+	echo "Cleaning up tmp dir '$tmp_dir'"
+        rm -rf $tmp_dir
+    fi
 done;
+

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -24,8 +24,7 @@ fi
 echo "Using $CONFIG_FILE config files for processes"
 
 # if $TEST_RESULTS_DIR not defined already then set to default path
-if [[ -z ${TEST_RESULTS_DIR} ]]; 
-then
+if [[ -z ${TEST_RESULTS_DIR} ]]; then
     TEST_RESULTS_DIR=tests/test_results
 fi
 
@@ -36,8 +35,7 @@ echo "Test results will be written in $TEST_RESULTS_DIR"
 
 set +e
 
-if [[ -z ${EFI_CONFIG_FILE+1} || -z ${EFI_DB_NAME+1} || -z ${EFI_FASTA_DB+1} || -z ${EFI_TEST_ACC_FILE+1} || -z ${EFI_TEST_FASTA_FILE+1} || -z ${EFI_TEST_BLAST_SEQ+1} || -z ${EFI_TEST_ENV+1} || -z ${EFI_TEST_FAMILY_ID+1} ]];
-then
+if [[ -z ${EFI_CONFIG_FILE+1} || -z ${EFI_DB_NAME+1} || -z ${EFI_FASTA_DB+1} || -z ${EFI_TEST_ACC_FILE+1} || -z ${EFI_TEST_FASTA_FILE+1} || -z ${EFI_TEST_BLAST_SEQ+1} || -z ${EFI_TEST_ENV+1} || -z ${EFI_TEST_FAMILY_ID+1} ]]; then
     echo "Test environment variables not found, please run 'source tests/test_env.sh mysql' or 'source tests/test_env.sh sqlite'"
     exit 1
 elif [[ "$EFI_TEST_ENV" != "mysql" && ! -d "$EFI_TEST_DATA_DIR" ]]; then

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -31,7 +31,7 @@ set +e
 
 if [[ -z ${EFI_CONFIG_FILE+1} || -z ${EFI_DB_NAME+1} || -z ${EFI_FASTA_DB+1} || -z ${EFI_TEST_ACC_FILE+1} || -z ${EFI_TEST_FASTA_FILE+1} || -z ${EFI_TEST_BLAST_SEQ+1} || -z ${EFI_TEST_ENV+1} || -z ${EFI_TEST_FAMILY_ID+1} ]];
 then
-    echo "Test environment variables not found, please source tests/test_env.sh mysql or sqlite"
+    echo "Test environment variables not found, please run 'source tests/test_env.sh mysql' or 'source tests/test_env.sh sqlite'"
     exit 1
 elif [[ "$EFI_TEST_ENV" != "mysql" && ! -d "$EFI_TEST_DATA_DIR" ]]; then
     echo "Test data directory not found, attempting to download"

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -15,7 +15,7 @@ if [[ ! -e pipelines/generatessn/generatessn.nf || ! -e pipelines/est/est.nf ]];
     exit 1
 fi
 
-if [ $# -ne 1 ]; then
+if [[ $# -ne 1 ]]; then
     CONFIG_FILE="docker.config"
 else
     CONFIG_FILE=$1
@@ -29,7 +29,7 @@ then
     TEST_RESULTS_DIR=tests/test_results
 fi
 
-if [ ! -d $TEST_RESULTS_DIR ]; then 
+if [[ ! -d $TEST_RESULTS_DIR ]]; then 
     mkdir -p $TEST_RESULTS_DIR
 fi
 echo "Test results will be written in $TEST_RESULTS_DIR"


### PR DESCRIPTION
- Relocated testing output to `/tmp/nextflow/efi_tests/` directory tree. 
- Used the `mktemp` command to create a unique directory tree for each module's tests; this setup allows for a user to run multiple rounds of tests without having to clean up the test directory trees via a `rm -rf $OUTPUT_DIR` call within each module's .sh file. Removed all calls to an `$OUTPUT_DIR` variable. The `mktemp` unique directory path is stored in the `$tmp_dir` var in `runtests.sh` and is passed as an argument to each module's .sh file.
- In `runtests.sh`, added a check for whether the `bash "tests/modules/$file" $tmp_dir $CONFIG_FILE` call was successful. If it was, the code will report that to the user and then clean up the test directory associated with that call. **Note:** the `rm -rf $tmp_dir` line is currently commented out so that the directory tree changes can be observed when tests are run. Upon accepting this change, I'll uncomment out this line so that cleaning of files is done automatically.   
- Added a `make tests-clean` recipe to the Makefile.

edited for clarity.