### PR TITLE
add missing `executor = "local"`

### DIFF
--- a/conf/colorssn/pbspro.config
+++ b/conf/colorssn/pbspro.config
@@ -8,6 +8,7 @@ executor {
 }
 
 process {
+    executor = 'local'
     cpus = 1
     memory = 8.GB
 

--- a/conf/generatessn/pbspro.config
+++ b/conf/generatessn/pbspro.config
@@ -8,6 +8,7 @@ executor {
 }
 
 process {
+    executor = 'local'
     cpus = 1
     memory = 16.GB
 


### PR DESCRIPTION
Quick fix for the pbspro.config file issues. 