### PR TITLE
add igraph to module list

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -40,3 +40,4 @@ dependencies:
       - tomli==2.0.1
       - tzdata==2024.1
       - urllib3==2.2.1
+      - igraph==0.11.6


### PR DESCRIPTION
`igraph` module is used in the python script that gets called during the colorssn.nf `color_and_retrieve:compute_clusters` process. Need to include this module in the env.yml file so that builds using that file can run the colorssn.nf pipeline.  