### PR TITLE
123 fix pod formatting

### DIFF
--- a/docs/source/lib/EFI/GNT/Neighborhood.pm.rst
+++ b/docs/source/lib/EFI/GNT/Neighborhood.pm.rst
@@ -39,8 +39,8 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-EFI::GNT::Neighborhood is a Perl module for retrieving the sequences and
-metadata of genomes that are neighbors to a query sequence.
+**EFI::GNT::Neighborhood** is a Perl module for retrieving the sequences
+and metadata of genomes that are neighbors to a query sequence.
 
 
 
@@ -52,7 +52,7 @@ METHODS
 ``new(dbh => $dbh)``
 ~~~~~~~~~~~~~~~~~~~~
 
-Creates a new ``EFI::GNT::Neighborhood`` object.
+Creates a new **EFI::GNT::Neighborhood** object.
 
 
 
@@ -60,7 +60,7 @@ Parameters
 ^^^^^^^^^^
 
 ``dbh``
-   Database handle that comes from ``EFI::Database``.
+   Database handle that comes from **EFI::Database**.
 
 
 

--- a/docs/source/pipelines/est/import/append_blast_query.rst
+++ b/docs/source/pipelines/est/import/append_blast_query.rst
@@ -5,18 +5,16 @@ Usage
 
 ::
 
-	Usage: perl pipelines/est/import/append_blast_query.pl --blast-query-file path_to_file
-	    [--output-sequence-file <path/to/output/sequences/file.fasta>]
-	    [--output-dir <path/to/output/dir>]
+	Usage: perl append_blast_query.pl --blast-query-file <FILE> [--output-sequence-file <FILE>]
+	    [--output-dir <FILE>]
 	
 	Description:
-	    Append the input BLAST query to the sequence import file
+	    Append the input BLAST query to the sequence import file.
 	
 	Options:
-	    --blast-query-file      file that contains the BLAST query sequence
-	    --output-sequence-file  file that contains the sequences already retrieved by the pipeline
-	    --output-dir            directory that contains the files for the job
-	
+	    --blast-query-file        path to file containing the BLAST query sequence
+	    --output-sequence-file    path to output sequence file that the input sequence gets appended to
+	    --output-dir              path to directory containing input files for the EST job
 
 Reference
 ---------

--- a/docs/source/pipelines/est/import/get_sequence_ids.rst
+++ b/docs/source/pipelines/est/import/get_sequence_ids.rst
@@ -200,15 +200,6 @@ begin with the letters ``ZZ``.
 
 
 
-Example Usage
-^^^^^^^^^^^^^
-
-::
-
-   get_sequence_ids.pl --mode fasta --fasta <USER_FASTA_FILE>
-
-
-
 Parameters
 ^^^^^^^^^^
 
@@ -222,8 +213,17 @@ Parameters
    the **``import_fasta.pl``** script which reformats the user FASTA
    file into an acceptable format with proper header IDs. If this is not
    specified, the file is named according to the ``seq_mapping`` value
-   in the **``EFI::Import::Config::Defaults``** module and put in the
-   output directory.
+   in the **EFI::Import::Config::Defaults** module and put in the output
+   directory.
+
+
+
+Example Usage
+^^^^^^^^^^^^^
+
+::
+
+   get_sequence_ids.pl --mode fasta --fasta <USER_FASTA_FILE>
 
 
 
@@ -235,9 +235,8 @@ The import options share a number of arguments.
 ``--sequence-ids-file`` (optional, defaults)
    The output file that the IDs from the sequence ID retrieval are
    stored in. If this is not specified, the file is named according to
-   the ``accession_ids`` value in the
-   **``EFI::Import::Config::Defaults``** module and put in the output
-   directory.
+   the ``accession_ids`` value in the **EFI::Import::Config::Defaults**
+   module and put in the output directory.
 
 ``--mode`` (required)
    Specifies the mode; supported values are ``blast``, ``family``, and
@@ -265,23 +264,22 @@ The import options share a number of arguments.
    used.
 
 ``--output-metadata-file`` (optional, defaults)
-   The script also outputs a metadata file (see
-   **``EFI::EST::Metadata``** for the format of this file). If this is
-   not specified, the file is named according to the
-   ``sequence_metadata`` value in the
-   **``EFI::Import::Config::Defaults``** module and put in the output
+   The script also outputs a metadata file (see **EFI::EST::Metadata**
+   for the format of this file). If this is not specified, the file is
+   named according to the ``sequence_metadata`` value in the
+   **EFI::Import::Config::Defaults** module and put in the output
    directory.
 
 ``--output-sunburst-ids-file-`` (optional, defaults)
    The EST graphical tools support the display of taxonomy in the form
    of sunburst diagrams. If this is not specified, the file is named
    according to the ``sunburst_ids`` value in the
-   **``EFI::Import::Config::Defaults``** module and put in the output
+   **EFI::Import::Config::Defaults** module and put in the output
    directory.
 
 ``--output-stats-file`` (optional, defaults)
    Statistics are computed for the sequences that are retrieved (e.g.
    size of family, number of sequences). If this is not specified, the
    file is named according to the ``import_stats`` value in the
-   **``EFI::Import::Config::Defaults``** module and put in the output
+   **EFI::Import::Config::Defaults** module and put in the output
    directory.

--- a/docs/source/pipelines/est/import/import_fasta.rst
+++ b/docs/source/pipelines/est/import/import_fasta.rst
@@ -44,7 +44,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-For all import methods but FASTA, the ``get_sequences.pl`` script is
+For all import methods but FASTA, the **get_sequences.pl** script is
 used. This script is a replacement for that and is designed to work with
 FASTA sequences that do not have a proper sequence ID. It assigns
 anonymous sequence identifiers to the sequences and writes them to the
@@ -68,7 +68,7 @@ Arguments
    file that maps lines in the original user-specified FASTA file to
    anonymous sequence identifiers. If this is not specified, the file
    with the name corresponding to the ``seq_mapping`` value in the
-   **``EFI::Import::Config::Defaults``** module is used in the output
+   **EFI::Import::Config::Defaults** module is used in the output
    directory.
 
    This file is a two column format file with a header line, where the
@@ -81,5 +81,5 @@ Arguments
    that are reformatted and renamed based on the ``--seq-mapping-file``
    file. If this is not specified, the file with the name corresponding
    to the ``all_sequences`` value in the
-   **``EFI::Import::Config::Defaults``** module is used in the output
+   **EFI::Import::Config::Defaults** module is used in the output
    directory.

--- a/docs/source/pipelines/gnd/create_gnd.rst
+++ b/docs/source/pipelines/gnd/create_gnd.rst
@@ -1,5 +1,22 @@
 create_gnd
 ==========
+Usage
+-----
+
+::
+
+	Usage: perl create_gnd.pl --cluster-map <FILE> --gnd <FILE> --config <FILE> --db-name <VALUE>
+	    [--nb-size <VALUE>]
+	
+	Description:
+	    Computes the genome neighborhood network (GNN) from output from the Color SSN pipeline
+	
+	Options:
+	    --cluster-map    path to a file mapping sequence ID to cluster number
+	    --gnd            path to the output GND file
+	    --nb-size        neighborhood size (number of sequences to retrieve on either side of query
+	    --config         path to the config file for database connection
+	    --db-name        name of the EFI database to connect to for retrieving UniRef sequences
 
 Reference
 ---------

--- a/docs/source/pipelines/gnt/create_gnns.rst
+++ b/docs/source/pipelines/gnt/create_gnns.rst
@@ -1,5 +1,31 @@
 create_gnns
 ===========
+Usage
+-----
+
+::
+
+	Usage: perl create_gnns.pl --cluster-map <FILE> --cluster-gnn <FILE> --pfam-gnn <FILE>
+	    --config <FILE> --db-name <VALUE> [--gnd <FILE>] [--cooc-table <FILE>] [--hub-count <FILE>]
+	    [--nb-pfam-list-dir <DIR_PATH>] [--no-context <FILE>] [--nb-size <VALUE>]
+	    [--cooc-threshold <VALUE>]
+	
+	Description:
+	    Computes the genome neighborhood network (GNN) from output from the Color SSN pipeline
+	
+	Options:
+	    --cluster-map         path to a file mapping sequence ID to cluster number
+	    --cluster-gnn         path to the output cluster hub-spoke GNN XGMML file
+	    --pfam-gnn            path to the output Pfam hub-spoke GNN XGMML file
+	    --gnd                 path to the output GND file
+	    --cooc-table          path to the output Pfam co-occurence table file
+	    --hub-count           path to the output hub count table file
+	    --nb-pfam-list-dir    path to an output directory containing files for each Pfam hub
+	    --no-context          path to an output file to save a list of input IDs that didn't have an ENA entry or didn't have neighbors
+	    --nb-size             neighborhood size (number of sequences to retrieve on either side of query
+	    --cooc-threshold      Cooccurrence threshold (>= 0.0 and <= 1.0)
+	    --config              path to the config file for database connection
+	    --db-name             name of the EFI database to connect to for retrieving UniRef sequences
 
 Reference
 ---------

--- a/docs/source/pipelines/shared/perl/annotate_mapping_table.rst
+++ b/docs/source/pipelines/shared/perl/annotate_mapping_table.rst
@@ -1,5 +1,26 @@
 annotate_mapping_table
 ======================
+Usage
+-----
+
+::
+
+	Usage: perl annotate_mapping_table.pl --cluster-map <FILE> --mapping-table <FILE> --config <FILE>
+	    --db-name <VALUE> [--seqid-source-map <FILE>] [--cluster-color-map <FILE>]
+	    [--swissprot-table <FILE>]
+	
+	Description:
+	    Outputs a mapping table with UniProt ID, cluster number, cluster color, taxonomy ID, and
+	    species corresponding to the UniProt ID
+	
+	Options:
+	    --cluster-map          path to a file mapping sequence ID to cluster number
+	    --seqid-source-map     path to a file mapping repnode or UniRef IDs in the SSN to sequence IDs within the repnode or UniRef ID cluster (optional)
+	    --mapping-table        path to an output file to store mapping in
+	    --cluster-color-map    path to a file mapping cluster number (sequence count) to color (optional)
+	    --swissprot-table      path to an output file to store SwissProt mappings in (optional)
+	    --config               path to the config file for database connection
+	    --db-name              name of the EFI database to connect to for retrieving annotations
 
 Reference
 ---------

--- a/docs/source/pipelines/shared/perl/color_xgmml.rst
+++ b/docs/source/pipelines/shared/perl/color_xgmml.rst
@@ -1,5 +1,24 @@
 color_xgmml
 ===========
+Usage
+-----
+
+::
+
+	Usage: perl color_xgmml.pl --ssn <FILE> --color-ssn <FILE> --cluster-map <FILE>
+	    --cluster-num-map <FILE> [--cluster-color-map <FILE>]
+	
+	Description:
+	    Parses a SSN XGMML file and writes it to a new SSN file after coloring and numbering the nodes
+	    based on cluster. This is done without creating a DOM since elements are written one by one to
+	    the file as they are built.
+	
+	Options:
+	    --ssn                  path to input XGMML (XML) SSN file
+	    --color-ssn            path to output colored SSN (XGMML) file
+	    --cluster-map          path to output file mapping node index (col 1) to cluster numbers (num by seq, num by nodes)
+	    --cluster-num-map      path to input file containing the mapping of cluster number to cluster sizes
+	    --cluster-color-map    path to output file mapping cluster number (sequence count) to a color
 
 Reference
 ---------
@@ -26,7 +45,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-``color_xgmml.pl`` reads a SSN in the format of XGMML (XML) and writes
+**color_xgmml.pl** reads a SSN in the format of XGMML (XML) and writes
 it to a new file after adding cluster number and color attributes. The
 document is read and written in a stream-like fashion rather than
 creating and building a DOM for optimal memory usage.
@@ -56,4 +75,4 @@ Arguments
 
 ``--color-file``
    Path to a file containing the master color list. If not present then
-   the color map in ``EFI::Util::Colors`` is used.
+   the color map in **EFI::Util::Colors** is used.

--- a/docs/source/pipelines/shared/perl/compute_conv_ratio.rst
+++ b/docs/source/pipelines/shared/perl/compute_conv_ratio.rst
@@ -1,5 +1,22 @@
 compute_conv_ratio
 ==================
+Usage
+-----
+
+::
+
+	Usage: perl compute_conv_ratio.pl --cluster-map <FILE> --index-seqid-map <FILE> --edgelist <FILE>
+	    --conv-ratio <FILE> [--seqid-source-map <FILE>]
+	
+	Description:
+	    Outputs a file listing the convergence ratio for each cluster in the input cluster map
+	
+	Options:
+	    --cluster-map         path to a file mapping sequence ID to cluster number
+	    --index-seqid-map     path to a file mapping the node index (edgelist ID) to sequence ID
+	    --edgelist            path to a file with the edgelist
+	    --conv-ratio          path to an output file to save convergence ratios
+	    --seqid-source-map    path to a file mapping repnode or UniRef IDs in the SSN to sequence IDs within the repnode or UniRef ID cluster (optional)
 
 Reference
 ---------

--- a/docs/source/pipelines/shared/perl/compute_stats.rst
+++ b/docs/source/pipelines/shared/perl/compute_stats.rst
@@ -1,5 +1,21 @@
 compute_stats
 =============
+Usage
+-----
+
+::
+
+	Usage: perl compute_stats.pl --cluster-map <FILE> --seqid-source-map <FILE> --singletons <FILE>
+	    --stats <FILE>
+	
+	Description:
+	    Outputs a file listing the convergence ratio for each cluster in the input cluster map
+	
+	Options:
+	    --cluster-map         path to a file mapping sequence ID to cluster number
+	    --seqid-source-map    path to a file mapping repnode or UniRef IDs in the SSN to sequence IDs within the repnode or UniRef ID cluster (optional)
+	    --singletons          path to a file containing a list of singletons
+	    --stats               path to an output file to save statistics to
 
 Reference
 ---------

--- a/docs/source/pipelines/shared/perl/get_id_lists.rst
+++ b/docs/source/pipelines/shared/perl/get_id_lists.rst
@@ -1,5 +1,27 @@
 get_id_lists
 ============
+Usage
+-----
+
+::
+
+	Usage: perl get_id_lists.pl --cluster-map <FILE> --uniprot <DIR_PATH> --cluster-sizes <FILE>
+	    --config <FILE> --db-name <VALUE> [--uniref90 <DIR_PATH>] [--uniref50 <DIR_PATH>]
+	    [--seqid-source-map <FILE>] [--singletons <FILE>]
+	
+	Description:
+	    Organizes the IDs in the input cluster map file into files by cluster
+	
+	Options:
+	    --cluster-map         path to a file mapping sequence ID to cluster number
+	    --uniprot             path to an output directory for storing IDs in
+	    --uniref90            path to an output directory for storing UniRef90 IDs in (optional)
+	    --uniref50            path to an output directory for storing UniRef50 IDs in (optional)
+	    --seqid-source-map    path to a file mapping repnode or UniRef IDs in the SSN to sequence IDs within the repnode or UniRef ID cluster (optional)
+	    --singletons          path to a file listing the singletons
+	    --cluster-sizes       path to an output file to save cluster sizes to
+	    --config              path to the config file for database connection
+	    --db-name             name of the EFI database to connect to for retrieving UniRef sequences
 
 Reference
 ---------

--- a/docs/source/pipelines/shared/perl/get_sequences.rst
+++ b/docs/source/pipelines/shared/perl/get_sequences.rst
@@ -43,7 +43,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-``get_sequences.pl`` retrieves sequences from a BLAST-formatted
+**get_sequences.pl** retrieves sequences from a BLAST-formatted
 database. The sequences that are retrieved are specified in an input
 file provided on the command line.
 
@@ -63,12 +63,12 @@ Arguments
 ``--sequence-ids-file`` (optional, defaults)
    The path to the input file containing a list of sequence IDs. If this
    is not specified, the file with the name corresponding to the
-   ``accession_ids`` value in the **``EFI::Import::Config::Defaults``**
+   ``accession_ids`` value in the **EFI::Import::Config::Defaults**
    module is used from the output directory.
 
 ``--output-sequence-file`` (optional, defaults)
    The path to the output file containing all of the FASTA sequences
    that were retrieved from the database. If this is not specified, the
    file with the name corresponding to the ``all_sequences`` value in
-   the **``EFI::Import::Config::Defaults``** module is used in the
-   output directory.
+   the **EFI::Import::Config::Defaults** module is used in the output
+   directory.

--- a/docs/source/pipelines/shared/perl/ssn_to_id_list.rst
+++ b/docs/source/pipelines/shared/perl/ssn_to_id_list.rst
@@ -1,5 +1,22 @@
 ssn_to_id_list
 ==============
+Usage
+-----
+
+::
+
+	Usage: perl ssn_to_id_list.pl --ssn <FILE> --edgelist <FILE> --index-seqid <FILE> --id-index <FILE>
+	    --seqid-source-map <FILE>
+	
+	Description:
+	    Parses an XGMML file to retrieve an edgelist and mapping info
+	
+	Options:
+	    --ssn                 path to XGMML (XML) SSN file
+	    --edgelist            path to an output edgelist file (two column space-separated file)
+	    --index-seqid         path to an output file mapping node index to XGMML nodeseqid (and optionally node size for UniRef/repnodes)
+	    --id-index            path to an output file mapping XGMML node ID to node index
+	    --seqid-source-map    path to an output file for mapping metanodes (e.g. RepNode or UniRef node) to UniProt nodes [optional]; the file is created regardless, but if the input IDs are UniProt the file is empty
 
 Reference
 ---------

--- a/docs/source/pipelines/shared/perl/unzip_xgmml_file.rst
+++ b/docs/source/pipelines/shared/perl/unzip_xgmml_file.rst
@@ -1,5 +1,19 @@
 unzip_xgmml_file
 ================
+Usage
+-----
+
+::
+
+	Usage: perl unzip_xgmml_file.pl --in <FILE> --out <FILE> [--out-ext <FILE>]
+	
+	Description:
+	    Extracts the first .xgmml (or specified extension) file in the input archive.
+	
+	Options:
+	    --in         path to zip file
+	    --out        path to output first xgmml file to
+	    --out-ext    file extension to look for (defaults to xgmml)
 
 Reference
 ---------
@@ -8,7 +22,7 @@ Reference
 NAME
 ----
 
-``unzip_xgmml_file.pl`` - unzips a compressed XGMML file
+unzip_xgmml_file.pl - unzips a compressed XGMML file
 
 
 
@@ -17,17 +31,18 @@ SYNOPSIS
 
 ::
 
-   unzip_xgmml_file.pl --cluster-map <FILE> --seqid-source-map <FILE> --singletons <FILE>
-       --stats <FILE>
+   unzip_xgmml_file.pl --in <FILE> --out <FILE> [--out-ext <FILE_EXT>]
 
 
 
 DESCRIPTION
 -----------
 
-``unzip_xgmml_file.pl`` uncompresses the zip file and extracts the first
-XGMML file (``.xgmml`` extension>) that is found. It uses the system
-``unzip`` command.
+**unzip_xgmml_file.pl** uncompresses the zip file and extracts the first
+file matching the specified file extension by ``--out-ext``. If
+``--out-ext`` is not specified then the first XGMML file (with
+``.xgmml`` extension) is extracted. This script requires that the system
+have the **unzip** program installed.
 
 
 
@@ -35,11 +50,12 @@ Arguments
 ~~~~~~~~~
 
 ``--in``
-   Path to a zip file
+   Path to a zip file.
 
 ``--out``
-   Path to the location where the XGMML file should be stored
+   Path to the file where the XGMML file should be extracted to. If a
+   file at that path already exists it will be deleted.
 
 ``--out-ext``
    The file extension in the archive to look for (defaults to
-   ``.xgmml``)
+   ``.xgmml``).

--- a/lib/EFI/Annotations.pm
+++ b/lib/EFI/Annotations.pm
@@ -637,18 +637,19 @@ SQL return data from the C<annotations> table in the EFI database.
 
 =head2 DESCRIPTION
 
-EFI::Annotations is a utility module that provides helper functions for creating SQL statements
+B<EFI::Annotations> is a utility module that provides helper functions for creating SQL statements
 that can be used to query the EFI database C<annotations> table.  In addition, methods are provided
 for processing data rows returned from database query results.  Helper methods are provided
 for determining node attribute types.
 
 =head2 METHODS
 
-=head3 new()
+=head3 C<new()>
 
 Create an instance of EFI::Annotations.
 
-=head3 build_taxid_query_string($taxId)
+
+=head3 C<build_taxid_query_string($taxId)>
 
 Creates a SQL SELECT query statement based on a taxonomic identifier
 that can be provided to a SQL connection
@@ -673,7 +674,8 @@ SQL SELECT query statement.
     my $taxId = 1000;
     my $sqlSelect = $anno->build_taxid_query_string($taxId);
 
-=head3 build_query_string($accession, $extraWhere)
+
+=head3 C<build_query_string($accession, $extraWhere)>
 
 Creates a SQL SELECT query statement based on a sequence identifier
 that can be provided to a SQL connection
@@ -709,7 +711,8 @@ SQL SELECT query statement.
     my $extraWhere = "A." . FIELD_SEQ_LEN_KEY . " <= $maxLen";
     my $sqlSelect = $anno->build_query_string($accession, $extraWhere);
 
-=head3 build_id_mapping_query_string($accession)
+
+=head3 C<build_id_mapping_query_string($accession)>
 
 Creates a SQL SELECT query statement to retrieve IDs from the EFI database C<idmapping> table.
 This can be used to convert from UniProt IDs to non-UniProt IDs (e.g. RefSeq).
@@ -733,7 +736,8 @@ SQL SELECT query statement.
     my $accession = "B0SS77";
     my $sqlSelect = $anno->build_id_mapping_query_string($accession);
 
-=head3 build_annotations($dbRow, $ncbiIds, $annoSpec)
+
+=head3 C<build_annotations($dbRow, $ncbiIds, $annoSpec)>
 
 Creates a hash ref data structure from a database result row.
 The structure contains all of the node attributes that are in the results, formatted appropriately,
@@ -799,7 +803,8 @@ and a hash ref of values from the database row, mapping display field name to th
     #     "is_fragment" => "fragment",
     # }
 
-=head3 get_annotation_data()
+
+=head3 C<get_annotation_data()>
 
 Return metadata for all of the fields that are displayed in the SSN.
 
@@ -839,7 +844,8 @@ the order in which they appear, the display name, and the node type.
     #     ...
     # }
 
-=head3 get_ssn_annotation_fields()
+
+=head3 C<get_ssn_annotation_fields()>
 
 Returns a list of field names that are included by default in the SSN output.
 
@@ -857,7 +863,7 @@ A list of field names.
     #    ...
     # )
 
-=head3 decode_meta_struct($jsonString)
+=head3 C<decode_meta_struct($jsonString)>
 
 Decodes a JSON string from the C<annotations> table metadata column into a hash representing
 the values for that accession.  The metadata column uses short 1 or 2 character keys to
@@ -891,7 +897,8 @@ A hash ref containing the values from the JSON string.
     #     "ec_code" => "code"
     # }
 
-=head3 sort_annotations(@fields)
+
+=head3 C<sort_annotations(@fields)>
 
 Sorts the fields in the order in which they should appear in the SSN.
 
@@ -916,7 +923,8 @@ The input array, sorted by the internal C<order> field as specified in the modul
     @fieldNames = $anno->sort_annotations(@fieldNames);
     # @fieldNames will be ("organism", "NCBI_IDs", "ec_code").
 
-=head3 is_list_attribute($attrName)
+
+=head3 C<is_list_attribute($attrName)>
 
 Checks if the input attribute name is a SSN list attribute.
 
@@ -944,7 +952,7 @@ A SSN display attribute name (e.g. C<Organism>).
     my $isList = $anno->is_list_attribute($attrName);
     # $isList is 0
 
-=head3 get_attribute_type($attrName)
+=head3 C<get_attribute_type($attrName)>
 
 Returns the SSN node attribute data type for the attribute name.
 
@@ -972,7 +980,8 @@ The string "integer" if the type is numeric, "string" otherwise.
     my $theType = $anno->get_attribute_type($attrName);
     # $theType is "integer"
 
-=head3 is_expandable_attr($attrName)
+
+=head3 C<is_expandable_attr($attrName)>
 
 Checks if the input attribute name (or its display/SSN column name) can be expanded into a list of IDs.
 In other words, it checks if the input name is UniRef or repnode ID list attribute name.
@@ -1006,7 +1015,8 @@ A SSN display attribute name (e.g. C<UniRef90 IDs>).
     my $isExpandable = $anno->is_expandable_attr($attrName);
     # $isExpandable is 1
 
-=head3 get_expandable_attr()
+
+=head3 C<get_expandable_attr()>
 
 Gets a mapping of ID attribute display names (such as UniRef clusters or repnodes) that can be
 expanded into multiple IDs. See C<is_expandable_attr()> for a list of the currently available ones. 
@@ -1017,7 +1027,7 @@ expanded into multiple IDs. See C<is_expandable_attr()> for a list of the curren
 
 =item C<$fields>
 
-An array ref of fields from C<EFI::Annotations::Fields> relating to expandable attributes.
+An array ref of fields from B<EFI::Annotations::Fields> relating to expandable attributes.
 
 =item C<$display>
 
@@ -1035,7 +1045,7 @@ A hash ref mapping field name to field display for each element in C<$fields>.
     }
 
 
-=head3 get_attribute_info($attrName)
+=head3 C<get_attribute_info($attrName)>
 
 Gets information about the given attribute.
 
@@ -1073,7 +1083,7 @@ set and non-zero if they are XGMML list attribute types or numerical types, resp
     }
 
 
-=head3 get_cluster_info_insert_location()
+=head3 C<get_cluster_info_insert_location()>
 
 Returns the name of the SSN column where the cluster number and color columns should be inserted.
 This is designed so that the new columns will be inserted immediately following the returned column.
@@ -1090,7 +1100,8 @@ A string representing a SSN column heading (e.g. display name).
         # Append the color and cluster number column values
     }
 
-=head3 get_color_fields()
+
+=head3 C<get_color_fields()>
 
 Gets a list of color SSN attribute display names (such as cluster number and color).
 
@@ -1100,7 +1111,7 @@ Gets a list of color SSN attribute display names (such as cluster number and col
 
 =item C<$fields>
 
-An array ref of fields from C<EFI::Annotations::Fields> of the C<color> group.
+An array ref of fields from B<EFI::Annotations::Fields> of the C<color> group.
 
 =item C<$display>
 

--- a/lib/EFI/EST/Metadata.pm
+++ b/lib/EFI/EST/Metadata.pm
@@ -151,11 +151,11 @@ SSN metadata files are a superset of sequence metadata files and are created in 
 
 =head2 METHODS
 
-=head3 new()
+=head3 C<new()>
 
 Create an instance of EFI::Util::Metadata object.
 
-=head3 parseFile($file)
+=head3 C<parseFile($file)>
 
 Reads a metadata file and returns a hash with the data.
 A metadata file contains a header line and three columns.
@@ -193,7 +193,7 @@ The hash ref contains a structure of IDs and their associated node attributes:
         ...
     }
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $data = $parser->parseFile($metaFile);
 
@@ -203,7 +203,7 @@ The hash ref contains a structure of IDs and their associated node attributes:
         }
     }
 
-=head3 writeData($file, $data, $fields)
+=head3 C<writeData($file, $data, $fields)>
 
 Saves data to the specified file. The data is expected to be in the same format that C<parseFile> outputs.
 C<$fields> is an optional value, a hash ref which can be passed to restrict which fields are output.
@@ -227,7 +227,7 @@ If it is not provided, all values in the input data are written out.
 
 =back
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $data = {}; # some data in here
     

--- a/lib/EFI/GNT/Annotations.pm
+++ b/lib/EFI/GNT/Annotations.pm
@@ -222,7 +222,7 @@ EFI::GNT::Annotations - Perl module for retrieving annotations from the EFI data
 
 =head2 DESCRIPTION
 
-EFI::GNT::Annotations is a Perl module for retrieving metadata annotations from
+B<EFI::GNT::Annotations> is a Perl module for retrieving metadata annotations from
 the EFI database.  Metadata retrieved are the organism, taxonomy ID, annotation
 status (e.g. TrEMBL or SwissProt), and SwissProt description.
 
@@ -230,7 +230,7 @@ status (e.g. TrEMBL or SwissProt), and SwissProt description.
 
 =head3 C<new(dbh =E<gt> $dbh)>
 
-Creates a new C<EFI::GNT::Annotations> object.
+Creates a new B<EFI::GNT::Annotations> object.
 
 =head4 Parameters
 
@@ -238,7 +238,7 @@ Creates a new C<EFI::GNT::Annotations> object.
 
 =item C<dbh>
 
-Database handle that comes from C<EFI::Database>.
+Database handle that comes from B<EFI::Database>.
 
 =back
 

--- a/lib/EFI/GNT/Neighborhood.pm
+++ b/lib/EFI/GNT/Neighborhood.pm
@@ -602,14 +602,14 @@ EFI::GNT::Neighborhood - Perl module for retrieving the genome neighborhood of a
 
 =head2 DESCRIPTION
 
-EFI::GNT::Neighborhood is a Perl module for retrieving the sequences and metadata of genomes
+B<EFI::GNT::Neighborhood> is a Perl module for retrieving the sequences and metadata of genomes
 that are neighbors to a query sequence.
 
 =head2 METHODS
 
 =head3 C<new(dbh =E<gt> $dbh)>
 
-Creates a new C<EFI::GNT::Neighborhood> object.
+Creates a new B<EFI::GNT::Neighborhood> object.
 
 =head4 Parameters
 
@@ -617,7 +617,7 @@ Creates a new C<EFI::GNT::Neighborhood> object.
 
 =item C<dbh>
 
-Database handle that comes from C<EFI::Database>.
+Database handle that comes from B<EFI::Database>.
 
 =back
 

--- a/lib/EFI/IdMapping.pm
+++ b/lib/EFI/IdMapping.pm
@@ -95,13 +95,16 @@ EFI::IdMapping - Perl module for mapping non-UniProt protein sequence IDs to Uni
 
 =head2 DESCRIPTION
 
-EFI::IdMapping is a utility module that maps non-UniProt IDs (usually obtained from FASTA headers) to UniProt IDs.
-It does this by using the C<idmapping> table in an EFI database, which is in turn obtained from the UniProt ID mapping dataset.
-The most frequent non-UniProt ID type that is used is B<NCBI>, but other types are supported (as defined in the C<EFI::IdMapping::Util> module).
+B<EFI::IdMapping> is a utility module that maps non-UniProt IDs (usually obtained from FASTA
+headers) to UniProt IDs.  It does this by using the C<idmapping> table in an EFI database, which
+is in turn obtained from the UniProt ID mapping dataset.  The most frequent non-UniProt ID type
+that is used is B<NCBI>, but other types are supported (as defined in the B<EFI::IdMapping::Util>
+module).
+
 
 =head2 METHODS
 
-=head3 new(efi_dbh => $efiDbh)
+=head3 C<new(efi_dbh =E<gt> $efiDbh)>
 
 Create an instance of EFI::IdMapping object.
 
@@ -115,7 +118,8 @@ A database connection handle created by the B<EFI::Database> object.
 
 =back
 
-=head3 reverseLookup($typeHint, @searchIds)
+
+=head3 C<reverseLookup($typeHint, @searchIds)>
 
 Try to map IDs of unknown format to UniProt IDs.
 
@@ -125,7 +129,8 @@ Try to map IDs of unknown format to UniProt IDs.
 
 =item C<$typeHint>
 
-ID format guess, a constant from C<EFI::IdMapping::Util>. Usually C<AUTO>. See C<EFI::IdMapping::Util> for all options.
+ID format guess, a constant from B<EFI::IdMapping::Util>. Usually C<AUTO>. See
+B<EFI::IdMapping::Util> for all options.
 
 =item C<@searchIds>
 
@@ -151,7 +156,7 @@ A hash ref containing a mapping of UniProt IDs to a list of source IDs.
 
 =back
 
-=head4 Example usage:
+=head4 Example Usage
 
     my @searchIds = ("B0SS77", "WP_012388845.1");
     # Return a list of UniProt IDs that were found

--- a/lib/EFI/IdMapping/Util.pm
+++ b/lib/EFI/IdMapping/Util.pm
@@ -76,12 +76,12 @@ EFI::IdMapping::Util - Perl module containing helper functions and constants to 
 
 =head2 DESCRIPTION
 
-EFI::IdMapping::Util provides helper functions and exports constants for sequence ID mapping from
+B<EFI::IdMapping::Util> provides helper functions and exports constants for sequence ID mapping from
 non-UniProt ID types to UniProt IDs.
 
 =head2 METHODS
 
-=head3 check_id_type($id)
+=head3 C<check_id_type($id)>
 
 Determine the type of the given ID based on the structure of the string. 
 
@@ -99,11 +99,12 @@ A string containing an ID type.
 
 One of the known ID type constants, C<UNIPROT>, C<NCBI>, C<GENBANK>, C<GI>, or C<PDB>.
 
-=head4 Example usage:
+=head4 Example Usage
 
     if (check_id_type("B0SS77") eq UNIPROT) {
         print "ID is UniProt\n";
     }
+
 
 =head2 ID TYPES
 
@@ -123,6 +124,7 @@ A homologue identifier can be tacked on the end, in the form of C<.#>.  For exam
 C<GENBANK>, C<PDB>, and C<GI> are also identified but are not used frequently.
 
 =back
+
 
 =head2 CONSTANTS
 

--- a/lib/EFI/Options.pm
+++ b/lib/EFI/Options.pm
@@ -25,7 +25,10 @@ sub new {
     my $class = shift;
     my %args = @_;
 
-    my $self = { app => $args{app_name} // $0, help_desc => $args{desc} // "" };
+    my $appName = $args{app_name} // $0;
+    $appName =~ s%^.*/([^/]+)$%$1%; # only show the script, not path
+
+    my $self = { app => $appName, help_desc => $args{desc} // "" };
     bless $self, $class;
 
     return $self;

--- a/lib/EFI/Options.pm
+++ b/lib/EFI/Options.pm
@@ -216,16 +216,12 @@ sub printHelp {
     }
 
     # Print any errors that were discovered during validation
-    if (@{ $self->{errors} }) {
+    if (@{ $self->{errors} } and not $self->wantHelp()) {
         $text .= "\nErrors:\n";
         map { $text .= "    Missing or invalid argument --$self->{options}->{$_}->{opt}\n"; } @{ $self->{errors} };
     }
 
-    if ($helpOptions & OPT_PRINT_HELP) {
-        print $text;
-    } else {
-        return $text;
-    }
+    return $text;
 }
 
 
@@ -272,12 +268,12 @@ EFI::Options is a utility module to get command line arguments.
 
 =head2 METHODS
 
-=head3 new(parse_options...)
+=head3 C<new(parse_options...)>
 
 Create a new instance of this module.  The available parse options are C<app_name>, used
 to provide a custom name to the C<printHelp()> method, and C<desc>, also used in C<printHelp()>.
 
-=head3 addOption($optSpec, $required, $help, $resultType)
+=head3 C<addOption($optSpec, $required, $help, $resultType)>
 
 Adds an option to the list of available options.
 
@@ -313,14 +309,14 @@ types are C<OPT_VALUE>, C<OPT_FILE>, and C<OPT_DIR_PATH>.
 
 C<1> if the addition was a success, C<0> if the option already exists.
 
-=head4 Example usage:
+=head4 Example Usage
 
     $optParser->addOption("edgelist=s", 1, "path to a file with the edgelist", OPT_FILE);
     $optParser->addOption("file-type=s", 0, "type of the file (e.g. mapping, tab, xml)", OPT_VALUE); # Or, don't need to provide OPT_VALUE
     $optParser->addOption("finalize", 0, "finalize the computation");
 
 
-=head3 parseOptions()
+=head3 C<parseOptions()>
 
 Parses the command line arguments and validates them against the specification provided
 by the user in C<addOption>.  Called after all C<addOption>s are called.
@@ -329,7 +325,7 @@ by the user in C<addOption>.  Called after all C<addOption>s are called.
 
 C<1> if the parsing was a success and all required arguments were present; C<0> otherwise.
 
-=head4 Example usage:
+=head4 Example Usage
 
     if (not $optParser->parseOptions()) {
         my $text = $optParser->printHelp(OPT_ERRORS);
@@ -338,7 +334,7 @@ C<1> if the parsing was a success and all required arguments were present; C<0> 
     }
 
 
-=head3 getOptions()
+=head3 C<getOptions()>
 
 Return information about the options that were added and parsed.
 
@@ -349,7 +345,7 @@ command line, it will not be present in this hash ref.  The option key is the
 option name provided in the specification to C<addOption> with the dash C<-> replaced
 with underscores C<_>.
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $options = $optParser->getOptions();
 
@@ -358,7 +354,7 @@ with underscores C<_>.
     }
 
 
-=head3 wantHelp()
+=head3 C<wantHelp()>
 
 Determine if the user wants to display a help message.
 
@@ -366,7 +362,7 @@ Determine if the user wants to display a help message.
 
 C<1> if the user specified C<--help> on the command line, C<0> otherwise.
 
-=head4 Example usage:
+=head4 Example Usage
 
     $optParser->parseOptions();
 
@@ -377,7 +373,7 @@ C<1> if the user specified C<--help> on the command line, C<0> otherwise.
     }
 
 
-=head3 printHelp([$outputType])
+=head3 C<printHelp([$outputType])>
 
 Return or display help based on the input options added via C<addOption()>.
 
@@ -387,23 +383,20 @@ Return or display help based on the input options added via C<addOption()>.
 
 =item C<$outputType>
 
-Specifies the type of output and how to display it.  Multiple arguments are
-provided with the logical OR operator.  Available arguments are C<OPT_PRINT_HELP>
-and C<OPT_ERRORS>.  If C<OPT_ERRORS> is provided as an argument, then any
-errors encountered during parsing are displayed in addition to the help text.
+If the value is C<OPT_ERRORS>, then add the validation errors to the bottom of
+the help text.
 
 =back
 
 =head4 Returns
 
-If C<$outputType> includes C<OPT_PRINT_HELP> as an option, the help text is
-printed and the method returns nothing.  Otherwise the help text is returned.
+Return the usage, description, and option help text.
 
-=head4 Example usage:
+=head4 Example Usage
 
     $optParser->parseOptions();
-    my $text = $optParser->printHelp(OPT_ERRORS);
-    $optParser->printHelp(OPT_PRINT_HELP|OPT_ERRORS);
+    my $helpWithErrors = $optParser->printHelp(OPT_ERRORS);
+    my $helpOnly = $optParser->printHelp();
     
 
 =cut

--- a/lib/EFI/SSN/Util/ID.pm
+++ b/lib/EFI/SSN/Util/ID.pm
@@ -186,7 +186,7 @@ EFI::SSN::Util::ID - Perl module for parsing and performing various sequence ID-
 
 =head2 DESCRIPTION
 
-EFI::SSN::Util::ID is a utility module that provides functions to parse and manipulate
+B<EFI::SSN::Util::ID> is a utility module that provides functions to parse and manipulate
 files and structures that contain sequence ID information such as cluster number to IDs
 and metanodes.  A metanode is a node in the network that represents one or more sequences.
 For example, networks generated using UniRef will contain nodes that correspond to
@@ -201,7 +201,7 @@ and by-sequence and by-node numbering is identical.
 
 =head2 METHODS
 
-=head3 parse_cluster_map_file($clusterMapFile)
+=head3 C<parse_cluster_map_file($clusterMapFile)>
 
 Parses a file that contains a mapping of sequence IDs to cluster numbers.
 
@@ -251,13 +251,12 @@ C<cluster_num_node> column in the input file).  In the example given above
 
 =back
     
-=head4 Example usage:
+=head4 Example Usage
 
     my ($seqClusterToId, $nodeClusterToId) = parse_cluster_map_file($clusterMapFile);
 
 
-
-=head3 parse_metanode_map_file($metanodeMapFile)
+=head3 C<parse_metanode_map_file($metanodeMapFile)>
 
 Parses a file that contains a mapping of metanodes to nodes within the metanode.
 The result may be an empty hash ref in the case that the file is empty (which
@@ -289,15 +288,13 @@ A hash ref that maps metanode to a list of sequences. For example:
         ...
     }
 
-=head4 Example usage:
+=head4 Example Usage
 
     # $metanodeMapFile comes from another utility, ssn_to_id_list.pl
     my ($idType, $sourceIdMap) = parse_metanode_map_file($metanodeMapFile);
 
 
-
-
-=head3 resolve_mapping($clusterToId, $idType, $sourceIdMap)
+=head3 C<resolve_mapping($clusterToId, $idType, $sourceIdMap)>
 
 Expands any metanode IDs in the C<$clusterToId> data structure to the full set of sequences.
 For example, if cluster 1 contains 5 metanodes, with each one containing 3 sequences, the
@@ -357,7 +354,7 @@ the metanode).
         ...
     }
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $clusterToId = {}; # get the mapping somehow
     my $sourceIdMap = {}; # get the mapping somehow
@@ -370,9 +367,7 @@ the metanode).
     }
 
 
-
-
-=head3 get_cluster_num_cols($header)
+=head3 C<get_cluster_num_cols($header)>
 
 Returns the column index of the cluster number by sequence and by node in
 C<cluster_id_map> files. These are used when parsing rows in the file to
@@ -398,7 +393,7 @@ The column index of the clusters numbered by nodes.
 
 =back
 
-=head4 Example usage:
+=head4 Example Usage
 
     my ($seqNumCol, $nodeNumCol) = get_cluster_num_cols($header);
     chomp(my $row = getLine());

--- a/lib/EFI/SSN/XgmmlReader.pm
+++ b/lib/EFI/SSN/XgmmlReader.pm
@@ -212,9 +212,9 @@ C<id> attribute).
 
 =head2 METHODS
 
-=head3 new(xgmml_file => $ssnFile)
+=head3 C<new(xgmml_file =E<gt> $ssnFile)>
 
-Creates a new C<EFI::SSN::XgmmlReader> object.
+Creates a new B<EFI::SSN::XgmmlReader> object.
 
 =head4 Parameters
 
@@ -235,8 +235,7 @@ Returns an object.
     my $parser = EFI::SSN::XgmmlReader->new(xgmml_file => $ssnFile);
 
 
-
-=head3 parse
+=head3 C<parse()>
 
 Parses the XGMML file on a per-element basis. This method doesn't create a DOM;
 rather it obtains information from each XML element as the file is being parsed and
@@ -247,8 +246,7 @@ builds an internal representation of an SSN as a collection of arrays and hashes
     $parser->parse();
 
 
-
-=head3 getEdgeList
+=head3 C<getEdgeList()>
 
 Gets the edgelist, which is a list of edges where each edge is defined as
 a pair of node indices.
@@ -264,8 +262,7 @@ and target node indices.
     map { print join(" ", @$_), "\n"; } @$edgelist;
 
 
-
-=head3 getIndexSeqIdMap
+=head3 C<getIndexSeqIdMap()>
 
 Gets the structure that correlates node index to sequence ID.
 
@@ -279,8 +276,7 @@ A hash ref that maps node index to sequence ID (numeric -> string).
     map { print join("\t", $_, $indexSeqIdMap->{$_}), "\n"; } keys %$indexSeqIdMap;
 
 
-
-=head3 getIdIndexMap
+=head3 C<getIdIndexMap()>
 
 Gets a mapping of node IDs (the C<id> attribute in a SSN node) to node index.
 

--- a/lib/EFI/SSN/XgmmlReader/IdList.pm
+++ b/lib/EFI/SSN/XgmmlReader/IdList.pm
@@ -189,7 +189,7 @@ parsing and obtaining network information
 
 =head2 METHODS
 
-=head3 getMetanodeType
+=head3 C<getMetanodeType()>
 
 Gets the type of the metanodes in the network.
 
@@ -204,7 +204,7 @@ One of C<uniprot>, C<uniref90>, C<uniref50>, C<repnode>
 
 
 
-=head3 getMetanodeSizes
+=head3 C<getMetanodeSizes()>
 
 Gets the sizes of the metanodes in the network.
 
@@ -219,7 +219,7 @@ the metanode.  If the network is a UniProt network then this hash is empty.
 
 
 
-=head3 getMetanodes
+=head3 C<getMetanodes()>
 
 Gets metanodes from the network.
 
@@ -238,7 +238,7 @@ network then this hash is empty.
 
 
 
-=head3 getMetadata
+=head3 C<getMetadata()>
 
 Gets the metadata (node attributes) that is saved during parsing (currently only SwissProt
 description).  This is primarily used in the case that the network is UniProt; in that

--- a/lib/EFI/SSN/XgmmlWriter.pm
+++ b/lib/EFI/SSN/XgmmlWriter.pm
@@ -349,16 +349,16 @@ while inserting color and cluster number information
 
 =head2 DESCRIPTION
 
-EFI::SSN::XgmmlWriter is a Perl module for stream reading XGMML files and writing
+B<EFI::SSN::XgmmlWriter> is a Perl module for stream reading XGMML files and writing
 them to a new XGMML file while including metadata for nodes (e.g. things like colors,
-cluster numbers, etc.).  The C<EFI::SSN::XgmmlWriter::AttributeHandler> and
+cluster numbers, etc.).  The B<EFI::SSN::XgmmlWriter::AttributeHandler> and
 derived classes are used to provide metadata.
 
 =head2 METHODS
 
-=head3 new(ssn => $ssnFile, output_ssn => $outputSsn)
+=head3 C<new(ssn =E<gt> $ssnFile, output_ssn =E<gt> $outputSsn)>
 
-Creates a new C<EFI::SSN::XgmmlWriter> object.
+Creates a new B<EFI::SSN::XgmmlWriter> object.
 
 =head4 Parameters
 
@@ -370,24 +370,24 @@ Path to a SSN file in XGMML format (XML) that is to be parsed and rewritten.
 
 =back
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $xwriter = EFI::SSN::XgmmlWriter->new(ssn => $inputSsn, output_ssn => $outputSsn);
 
 
-=head3 write()
+=head3 C<write()>
 
 Parses the XGMML file on a per-element basis and writes the element to the output
 SSN. This method doesn't create a DOM; rather it obtains information from each
 XML element that is relevant to the input handlers and copies the element
 to the output file.
 
-=head4 Example usage:
+=head4 Example Usage
 
     $parser->write();
 
 
-=head3 addAttributeHandler($handler)
+=head3 C<addAttributeHandler($handler)>
 
 Adds a handler to the list of handlers that are called for each node attribute.
 
@@ -397,7 +397,7 @@ Adds a handler to the list of handlers that are called for each node attribute.
 
 =item C<$handler>
 
-An object derived from C<EFI::SSN::XgmmlWriter::AttributeHandler>.
+An object derived from B<EFI::SSN::XgmmlWriter::AttributeHandler>.
 
 =back
 

--- a/lib/EFI/SSN/XgmmlWriter/AttributeHandler.pm
+++ b/lib/EFI/SSN/XgmmlWriter/AttributeHandler.pm
@@ -76,24 +76,24 @@ for inserting attributes into an XGMML file from EFI::SSN::XgmmlWriter.
 
 =head2 DESCRIPTION
 
-C<EFI::SSN::XgmmlWriter::AttributeHandler> is a Perl module that provides an interface
+B<EFI::SSN::XgmmlWriter::AttributeHandler> is a Perl module that provides an interface
 that node handlers can inherit from.  Each subclass implements methods that are used
-by C<EFI::SSN::XgmmlWriter> to insert attributes into an XGMML file that is being written.
+by B<EFI::SSN::XgmmlWriter> to insert attributes into an XGMML file that is being written.
 
-=head4 Example usage:
+=head4 Example Usage
 
     # Inherits from EFI::SSN::XgmmlWriter
     my $colorHandler = EFI::SSN::XgmmlWriter::AttributeHandler::Color(...);
     $xwriter->addAttributeHandler($colorHandler);
 
 
-=head3 onInit()
+=head3 C<onInit()>
 
 Called before the input file is read and output file is written.  This is used to
 initialize variables that are necessary inside the handlers.
 
 
-=head3 onNodeStart($seqId, $id)
+=head3 C<onNodeStart($seqId, $id)>
 
 Called when the start of a node is encountered (e.g. the C<node> tag).
 
@@ -112,12 +112,12 @@ The Cytoscape identifier (e.g. C<id> attribute).  This may be the same as C<labe
 =back
 
 
-=head3 onNodeEnd()
+=head3 C<onNodeEnd()>
 
 Called when the end tag of a node is encountered.
 
 
-=head3 getSkipFieldInfo
+=head3 C<getSkipFieldInfo()>
 
 Gets a list of fields to skip when writing.  This is used so that the writer can insert
 new fields into the output SSN.
@@ -126,7 +126,7 @@ new fields into the output SSN.
 
 Array ref of field names in SSN display format (e.g. not internal naming convention).
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $fields = $h->getSkipFieldInfo();
     foreach my $f (@$fields) {
@@ -134,7 +134,7 @@ Array ref of field names in SSN display format (e.g. not internal naming convent
     }
 
 
-=head3 getNewAttributes
+=head3 C<getNewAttributes()>
 
 Get new attributes that are to be inserted at the current location in a node.
 
@@ -161,7 +161,7 @@ For example:
 
 If the third element isn't provided then the type of the attribute is assumed to be a string.
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $newAttr = $h->getNewAttributes($attName);
     foreach my $attr (@$newAttr) {

--- a/lib/EFI/SSN/XgmmlWriter/AttributeHandler/Color.pm
+++ b/lib/EFI/SSN/XgmmlWriter/AttributeHandler/Color.pm
@@ -165,18 +165,18 @@ based on cluster number into a SSN.
 
 =head2 DESCRIPTION
 
-C<EFI::SSN::XgmmlWriter::AttributeHandler::Color> is a Perl module that is a node handler
+B<EFI::SSN::XgmmlWriter::AttributeHandler::Color> is a Perl module that is a node handler
 used by EFI::SSN::XgmmlWriter to insert attributes into an XGMML file that is being written.
 This handler saves new node attributes into each node that specifies colors based on
 the cluster number.  The node attributes are inserted into the node at a location that
-is determined by a method in the C<EFI::Annotations> class.
+is determined by a method in the B<EFI::Annotations> class.
 
 
 =head2 METHODS
 
-=head3 new(cluster_map => $clusterMap, colors => $colors, cluster_sizes => $sizes)
+=head3 C<new(cluster_map =E<gt> $clusterMap, colors =E<gt> $colors, cluster_sizes =E<gt> $sizes)>
 
-Creates a new C<EFI::SSN::XgmmlWriter::AttributeHandler::Color> object and uses the
+Creates a new B<EFI::SSN::XgmmlWriter::AttributeHandler::Color> object and uses the
 given parameters to determine node colors.
 
 =head4 Parameters
@@ -191,7 +191,7 @@ in cluster and the second element is the cluster number based on nodes in cluste
 
 =item C<colors>
 
-A C<EFI::Util::Colors> object used for retrieving the color of a node based
+A B<EFI::Util::Colors> object used for retrieving the color of a node based
 on cluster number.
 
 =item C<cluster_sizes>
@@ -213,14 +213,14 @@ of nodes.  For example:
 
 =back
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $colorHandler = EFI::SSN::XgmmlWriter::AttributeHandler::Color(cluster_map => $clusterMap,
         colors => $colors, cluster_sizes => $sizes);
     $xwriter->addAttributeHandler($colorHandler);
 
 
-=head3 getClusterColors()
+=head3 C<getClusterColors()>
 
 Returns a mapping of cluster numbers (based on number of sequences) to color.
 

--- a/lib/EFI/Util/FASTA/Headers.pm
+++ b/lib/EFI/Util/FASTA/Headers.pm
@@ -163,12 +163,13 @@ EFI::Util::FASTA::Headers - Perl module for parsing ID information from FASTA he
 
 =head2 DESCRIPTION
 
-EFI::Util::FASTA::Headers is a utility module that parses sequence IDs out of FASTA headers and maps them to UniProt IDs if they are not a UniProt ID.
-Information about the ID is included in the header return value that can be used for sequence metadata.
+B<EFI::Util::FASTA::Headers> is a utility module that parses sequence IDs out of FASTA headers and
+maps them to UniProt IDs if they are not a UniProt ID. Information about the ID is included in the
+header return value that can be used for sequence metadata.
 
 =head2 METHODS
 
-=head3 new(efi_dbh => $efiDbh)
+=head3 C<new(efi_dbh =E<gt> $efiDbh)>
 
 Create an instance of EFI::IdMapping object.
 
@@ -182,7 +183,7 @@ A database connection handle created by the B<EFI::Database> object.
 
 =back
 
-=head3 parseLineForHeaders($line)
+=head3 C<parseLineForHeaders($line)>
 
 Determine if a line is a FASTA header, extract ID information, and return the result.
 
@@ -264,7 +265,7 @@ characters of the header string for UniProt IDs or IDs that map to UniProt IDs.
             raw_header => "info XP_007754113.1 metadata and other information"
         }
 
-=head4 Example usage:
+=head4 Example Usage
 
     my $header = $parser->parseLineForHeaders($line);
     if ($header->{uniprot_id}) {

--- a/pipelines/est/import/append_blast_query.pl
+++ b/pipelines/est/import/append_blast_query.pl
@@ -11,25 +11,17 @@ use lib "$FindBin::Bin/../../../lib";
 
 use EFI::Annotations::Fields qw(INPUT_SEQ_ID);
 use EFI::Import::Config::Defaults;
+use EFI::Options;
 
 
 
-my ($blastQueryFile, $outputSeqFile, $outputDir, $wantHelp);
-my $result = GetOptions(
-    "blast-query-file=s" => \$blastQueryFile,
-    "output-sequence-file=s" => \$outputSeqFile,
-    "output-dir=s" => \$outputDir,
-    "help" => \$wantHelp,
-);
 
-$outputDir = getcwd() if not $outputDir;
-
-checkArgs();
+# Exits if help is requested or errors are encountered
+my $opts = validateAndProcessOptions();
 
 
-
-open my $queryFh, "<", $blastQueryFile or die "Unable to read blast query file $blastQueryFile: $!";
-open my $outFh, ">>", $outputSeqFile or die "Unable to append to sequence file $outputSeqFile: $!";
+open my $queryFh, "<", $opts->{blast_query_file} or die "Unable to read blast query file $opts->{blast_query_file}: $!";
+open my $outFh, ">>", $opts->{output_sequence_file} or die "Unable to append to sequence file $opts->{output_sequence_file}: $!";
 
 $outFh->print(">" . &INPUT_SEQ_ID, "\n");
 while (my $line = <$queryFh>) {
@@ -42,50 +34,37 @@ close $queryFh;
 
 
 
-sub checkArgs {
-    printHelp() and exit(0) if $wantHelp;
 
-    my $fail = 0;
-    if (not $blastQueryFile or not -f $blastQueryFile) {
-        print "Require --blast-query-file containing the FASTA sequence to use for the BLAST\n";
-        $fail = 1;
+
+sub validateAndProcessOptions {
+
+    my $desc = "Append the input BLAST query to the sequence import file.";
+
+    my $optParser = new EFI::Options(app_name => $0, desc => $desc);
+
+    $optParser->addOption("blast-query-file=s", 1, "path to file containing the BLAST query sequence", OPT_FILE);
+    $optParser->addOption("output-sequence-file=s", 0, "path to output sequence file that the input sequence gets appended to", OPT_FILE);
+    $optParser->addOption("output-dir=s", 0, "path to directory containing input files for the EST job", OPT_FILE);
+
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
-    if (not $outputSeqFile) {
-        $outputSeqFile = get_default_path("all_sequences", $outputDir);
+
+    my $opts = $optParser->getOptions();
+
+    $opts->{output_dir} = getcwd() if not $opts->{output_dir};
+    if (not $opts->{output_sequence_file}) {
+        $opts->{output_sequence_file} = get_default_path("all_sequences", $opts->{output_dir});
     }
 
-    if ($fail) {
-        printHelp();
-        exit(1);
-    }
-}
-
-
-sub printHelp {
-    print <<HELP;
-Usage: perl $0 --blast-query-file path_to_file
-    [--output-sequence-file <path/to/output/sequences/file.fasta>]
-    [--output-dir <path/to/output/dir>]
-
-Description:
-    Append the input BLAST query to the sequence import file
-
-Options:
-    --blast-query-file      file that contains the BLAST query sequence
-    --output-sequence-file  file that contains the sequences already retrieved by the pipeline
-    --output-dir            directory that contains the files for the job
-
-HELP
-    exit(0);
+    return $opts;
 }
 
 
 
 
-
-
-
-
+1;
 __END__
 
 =head1 append_blast_query.pl
@@ -111,4 +90,7 @@ BLAST import option for EST generates import sequences that are used for the all
 pipeline.  By default the query sequence (the sequence the user provided for the BLAST option)
 is not included in the import sequences.  This script takes that query sequence and appends it to
 the import sequence file.
+
+
+=cut
 

--- a/pipelines/est/import/get_sequence_ids.pl
+++ b/pipelines/est/import/get_sequence_ids.pl
@@ -141,10 +141,11 @@ use by a script later in the EST import pipeline
 
 =head2 DESCRIPTION
 
-This script retrieves sequence IDs from a database or file and saves them for use by a script later in the EST import pipeline.
-There are four EST import modes available: BLAST, Family, Accessions, and FASTA.  
-See C<import_fasta.pl> for extra functionality required to complete the FASTA import option.
-In addition to outputting a file containing sequence identifiers, a metadata file is output that contains basic information about the sequences (e.g. how they were obtained).
+This script retrieves sequence IDs from a database or file and saves them for use by a script
+later in the EST import pipeline. There are four EST import modes available: BLAST, Family,
+Accessions, and FASTA.  See C<import_fasta.pl> for extra functionality required to complete the
+FASTA import option.  In addition to outputting a file containing sequence identifiers, a metadata
+file is output that contains basic information about the sequences (e.g. how they were obtained).
 
 =head2 MODES
 
@@ -159,10 +160,11 @@ the BLAST step might look like this:
 
 C<QUERY_FILE> is the path to the file that contains the user-specified query.
 C<BLAST_IMPORT_DB> is the path to a BLAST-formatted database.
-C<BLAST_EVALUE> and <BLAST_NUM_MATCHES> are the e-value to use and the maximum number of matches to return from the BLAST, respectively.
-The process generates a C<blast_hits.tab> file.  Assuming the process completed successfully, the next step is
-to run this script.  An additional output from the script is the C<blast_hits.tab> file, which is used
-during SSN generation for the BLAST import option only.
+C<BLAST_EVALUE> and <BLAST_NUM_MATCHES> are the e-value to use and the maximum number of matches
+to return from the BLAST, respectively.  The process generates a C<blast_hits.tab> file.  Assuming
+the process completed successfully, the next step is to run this script.  An additional output from
+the script is the C<blast_hits.tab> file, which is used during SSN generation for the BLAST import
+option only.
 
 =head4 Example Usage
 
@@ -184,8 +186,8 @@ The file that contains the user FASTA query sequence.
 
 =head3 B<Family>
 
-The Family import option uses one or more protein families to retrieve a list of IDs. The families that
-are supported are Pfam, InterPro, Pfam clans, SSF, and GENE3D.
+The Family import option uses one or more protein families to retrieve a list of IDs.  The families
+that are supported are Pfam, InterPro, Pfam clans, SSF, and GENE3D.
 
 =head4 Example Usage
 
@@ -228,13 +230,10 @@ A path to a file containing sequence IDs.  Each identifier should be on a separa
 =head3 B<FASTA>
 
 The FASTA import option parses sequence IDs from FASTA headers in a user-specified FASTA file.
-The headers are parsed to identify UniProt sequence IDs, and if non-UniProt IDs are detected, attempts to map those back to UniProt IDs.
-The result is an accession ID list file with only UniProt IDs.
-Additionally, if sequences could not be identified as UniProt or mapped to UniProt, anonymous sequence IDs are assigned that begin with the letters C<ZZ>.
-
-=head4 Example Usage
-
-    get_sequence_ids.pl --mode fasta --fasta <USER_FASTA_FILE>
+The headers are parsed to identify UniProt sequence IDs, and if non-UniProt IDs are detected,
+attempts to map those back to UniProt IDs.  The result is an accession ID list file with only
+UniProt IDs.  Additionally, if sequences could not be identified as UniProt or mapped to UniProt,
+anonymous sequence IDs are assigned that begin with the letters C<ZZ>.
 
 =head4 Parameters
 
@@ -246,12 +245,17 @@ A path to a file containing FASTA sequences.  Identifiers are pulled from the se
 
 =item C<--seq-mapping-file> (optional, defaults)
 
-This file is necessary to map UniProt or anonymous identifiers to the proper header line in the input FASTA file.
-The file is provided to the B<C<import_fasta.pl>> script which reformats the user FASTA file into an acceptable format with proper header IDs.
-If this is not specified, the file is named according to the C<seq_mapping> value in the B<C<EFI::Import::Config::Defaults>> module and put in the output directory.
+This file is necessary to map UniProt or anonymous identifiers to the proper header line in the
+input FASTA file.  The file is provided to the B<C<import_fasta.pl>> script which reformats the
+user FASTA file into an acceptable format with proper header IDs.  If this is not specified, the
+file is named according to the C<seq_mapping> value in the B<EFI::Import::Config::Defaults> module
+and put in the output directory.
 
 =back
 
+=head4 Example Usage
+
+    get_sequence_ids.pl --mode fasta --fasta <USER_FASTA_FILE>
 
 
 =head3 Shared Arguments
@@ -264,7 +268,7 @@ The import options share a number of arguments.
 
 The output file that the IDs from the sequence ID retrieval are stored in.
 If this is not specified, the file is named according to the C<accession_ids> value
-in the B<C<EFI::Import::Config::Defaults>> module and put in the output directory.
+in the B<EFI::Import::Config::Defaults> module and put in the output directory.
 
 =item C<--mode> (required)
 
@@ -293,22 +297,22 @@ specified, the current working directory is used.
 
 =item C<--output-metadata-file> (optional, defaults)
 
-The script also outputs a metadata file (see B<C<EFI::EST::Metadata>> for the format of this file).
+The script also outputs a metadata file (see B<EFI::EST::Metadata> for the format of this file).
 If this is not specified, the file is named according to the C<sequence_metadata> value
-in the B<C<EFI::Import::Config::Defaults>> module and put in the output directory.
+in the B<EFI::Import::Config::Defaults> module and put in the output directory.
 
 =item C<--output-sunburst-ids-file-> (optional, defaults)
 
 The EST graphical tools support the display of taxonomy in the form of sunburst diagrams.
 If this is not specified, the file is named according to the C<sunburst_ids> value
-in the B<C<EFI::Import::Config::Defaults>> module and put in the output directory.
+in the B<EFI::Import::Config::Defaults> module and put in the output directory.
 
 =item C<--output-stats-file> (optional, defaults)
 
 Statistics are computed for the sequences that are retrieved (e.g. size of family,
 number of sequences).
 If this is not specified, the file is named according to the C<import_stats> value
-in the B<C<EFI::Import::Config::Defaults>> module and put in the output directory.
+in the B<EFI::Import::Config::Defaults> module and put in the output directory.
 
 =back
 

--- a/pipelines/est/import/import_fasta.pl
+++ b/pipelines/est/import/import_fasta.pl
@@ -101,7 +101,7 @@ import_fasta.pl - import user-specified FASTA sequences into a form usable by th
 
 =head2 DESCRIPTION
 
-For all import methods but FASTA, the C<get_sequences.pl> script is used.  This script is
+For all import methods but FASTA, the B<get_sequences.pl> script is used.  This script is
 a replacement for that and is designed to work with FASTA sequences that do not have a
 proper sequence ID.  It assigns anonymous sequence identifiers to the sequences and
 writes them to the standard C<all_sequences> file that is outputted from C<get_sequences.pl>.
@@ -124,7 +124,7 @@ current working directory if not specified.
 When C<get_sequence_ids.pl> is run in the FASTA mode, it outputs a file that maps
 lines in the original user-specified FASTA file to anonymous sequence identifiers.
 If this is not specified, the file with the name corresponding to the C<seq_mapping> value
-in the B<C<EFI::Import::Config::Defaults>> module is used in the output directory.
+in the B<EFI::Import::Config::Defaults> module is used in the output directory.
 
 This file is a two column format file with a header line, where the first column
 is the UniProt or anonymous ID and the second column is the line number where the
@@ -135,7 +135,7 @@ corresponding sequence header is located in the C<--user-uploaded-file> file.
 The path to the output file containing all of the FASTA sequences that are reformatted
 and renamed based on the C<--seq-mapping-file> file.
 If this is not specified, the file with the name corresponding to the C<all_sequences> value
-in the B<C<EFI::Import::Config::Defaults>> module is used in the output directory.
+in the B<EFI::Import::Config::Defaults> module is used in the output directory.
 
 =back
 

--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -50,16 +50,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("config=s", 1, "path to the config file for database connection", OPT_FILE);
     $optParser->addOption("db-name=s", 1, "name of the EFI database to connect to for retrieving UniRef sequences");
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/gnt/create_gnns.pl
+++ b/pipelines/gnt/create_gnns.pl
@@ -88,16 +88,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("config=s", 1, "path to the config file for database connection", OPT_FILE);
     $optParser->addOption("db-name=s", 1, "name of the EFI database to connect to for retrieving UniRef sequences");
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/shared/perl/annotate_mapping_table.pl
+++ b/pipelines/shared/perl/annotate_mapping_table.pl
@@ -207,16 +207,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("config=s", 1, "path to the config file for database connection", OPT_FILE);
     $optParser->addOption("db-name=s", 1, "name of the EFI database to connect to for retrieving annotations");
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/shared/perl/color_xgmml.pl
+++ b/pipelines/shared/perl/color_xgmml.pl
@@ -1,4 +1,3 @@
-
 use strict;
 use warnings;
 
@@ -180,16 +179,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("cluster-num-map=s", 1, "path to input file containing the mapping of cluster number to cluster sizes", OPT_FILE);
     $optParser->addOption("cluster-color-map=s", 0, "path to output file mapping cluster number (sequence count) to a color", OPT_FILE);
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/shared/perl/color_xgmml.pl
+++ b/pipelines/shared/perl/color_xgmml.pl
@@ -203,7 +203,7 @@ C<color_xgmml.pl> - read a SSN XGMML file and write it to a new file after addin
 
 =head2 DESCRIPTION
 
-C<color_xgmml.pl> reads a SSN in the format of XGMML (XML) and writes it to a new file after
+B<color_xgmml.pl> reads a SSN in the format of XGMML (XML) and writes it to a new file after
 adding cluster number and color attributes. The document is read and written in a stream-like
 fashion rather than creating and building a DOM for optimal memory usage.
 
@@ -236,7 +236,7 @@ as determined by the pipeline upstream
 =item C<--color-file>
 
 Path to a file containing the master color list.  If not present then the color map in
-C<EFI::Util::Colors> is used.
+B<EFI::Util::Colors> is used.
 
 =back
 

--- a/pipelines/shared/perl/compute_conv_ratio.pl
+++ b/pipelines/shared/perl/compute_conv_ratio.pl
@@ -229,16 +229,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("conv-ratio=s", 1, "path to an output file to save convergence ratios", OPT_FILE);
     $optParser->addOption("seqid-source-map=s", 0, "path to a file mapping repnode or UniRef IDs in the SSN to sequence IDs within the repnode or UniRef ID cluster (optional)", OPT_FILE);
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/shared/perl/compute_stats.pl
+++ b/pipelines/shared/perl/compute_stats.pl
@@ -131,16 +131,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("singletons=s", 1, "path to a file containing a list of singletons", OPT_FILE);
     $optParser->addOption("stats=s", 1, "path to an output file to save statistics to", OPT_FILE);
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/shared/perl/get_id_lists.pl
+++ b/pipelines/shared/perl/get_id_lists.pl
@@ -345,16 +345,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("config=s", 1, "path to the config file for database connection", OPT_FILE);
     $optParser->addOption("db-name=s", 1, "name of the EFI database to connect to for retrieving UniRef sequences");
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/shared/perl/get_sequences.pl
+++ b/pipelines/shared/perl/get_sequences.pl
@@ -74,7 +74,7 @@ get_sequences.pl - retrieve the FASTA sequences for each ID in a file with UniPr
 
 =head2 DESCRIPTION
 
-C<get_sequences.pl> retrieves sequences from a BLAST-formatted database.  The sequences that are retrieved
+B<get_sequences.pl> retrieves sequences from a BLAST-formatted database.  The sequences that are retrieved
 are specified in an input file provided on the command line.
 
 =head3 Arguments
@@ -94,13 +94,13 @@ current working directory if not specified.
 
 The path to the input file containing a list of sequence IDs.
 If this is not specified, the file with the name corresponding to the C<accession_ids> value
-in the B<C<EFI::Import::Config::Defaults>> module is used from the output directory.
+in the B<EFI::Import::Config::Defaults> module is used from the output directory.
 
 =item C<--output-sequence-file> (optional, defaults)
 
 The path to the output file containing all of the FASTA sequences that were retrieved from the database.
 If this is not specified, the file with the name corresponding to the C<all_sequences> value
-in the B<C<EFI::Import::Config::Defaults>> module is used in the output directory.
+in the B<EFI::Import::Config::Defaults> module is used in the output directory.
 
 =back
 

--- a/pipelines/shared/perl/ssn_to_id_list.pl
+++ b/pipelines/shared/perl/ssn_to_id_list.pl
@@ -177,16 +177,9 @@ sub validateAndProcessOptions {
     $optParser->addOption("id-index=s", 1, "path to an output file mapping XGMML node ID to node index", OPT_FILE);
     $optParser->addOption("seqid-source-map=s", 1, "path to an output file for mapping metanodes (e.g. RepNode or UniRef node) to UniProt nodes [optional]; the file is created regardless, but if the input IDs are UniProt the file is empty", OPT_FILE);
 
-    if (not $optParser->parseOptions()) {
-        my $text = $optParser->printHelp(OPT_ERRORS);
-        die "$text\n";
-        exit(1);
-    }
-
-    if ($optParser->wantHelp()) {
-        my $text = $optParser->printHelp();
-        print $text;
-        exit(0);
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
     }
 
     return $optParser->getOptions();

--- a/pipelines/shared/perl/unzip_xgmml_file.pl
+++ b/pipelines/shared/perl/unzip_xgmml_file.pl
@@ -1,74 +1,86 @@
 #!/usr/bin/env perl
 
-use Getopt::Long;
-use Capture::Tiny ':all';
-use File::Find;
+use Capture::Tiny qw(:all);
 use File::Copy;
-use File::Path 'rmtree';
+use File::Find;
+use File::Path qw(rmtree);
+use FindBin;
+use Getopt::Long;
+
+use lib "$FindBin::Bin/../../../lib";
+
+use EFI::Options;
 
 
-my ($zipFile, $outFile, $outputExt);
-my $result = GetOptions(
-    "in=s"          => \$zipFile,
-    "out=s"         => \$outFile,
-    "out-ext=s"     => \$outputExt,
-);
 
 
-my $usage = <<USAGE
-Usage: $0 --in <filename> --out <filename> [--out-ext <file_extension>]
-
-Description:
-    Extracts the first .xgmml (or specified extension) file in the input archive.
-
-Options:
-    --in         path to compressed zip file
-    --out        output file path to extract the first xgmml to
-    --out-ext    the file extension to look for (default to xgmml)
-USAGE
-;
+# Exits if help is requested or errors are encountered
+my $opts = validateAndProcessOptions();
 
 
-if (not -f $zipFile or not $outFile) {
-    die "$usage\n";
-}
-
-$outputExt = "xgmml" if not $outputExt;
-
-if (not isZip($zipFile)) {
+if (not isZip($opts->{in})) {
     die "Invalid file type: not a zip\n";
 }
 
-my $tempDir = "$outFile.tempunzip";
+
+# Extract the entire zip file to a temporary directory
+my $tempDir = "$opts->{out}.tempunzip";
 
 mkdir $tempDir or die "Unable to extract the zip file to $tempDir: $!";
 
-my $cmd = "unzip $zipFile -d $tempDir";
+my $cmd = "unzip $opts->{in} -d $tempDir";
 my ($out, $err) = capture {
     system($cmd);
 };
 
 die "There was an error executing $cmd: $err" if $err;
 
+
+# Find the first xgmml (or out-ext) file
 my $firstFile = "";
+my $wanted = sub {
+    my $ext = $opts->{out_ext};
+    if (not $firstFile and $_ =~ /\.$ext$/i) {
+        $firstFile = $File::Find::name;
+    }
+};
 
-find(\&wanted, $tempDir);
+find($wanted, $tempDir);
 
-if (-f $outFile) {
-    unlink $outFile or die "Unable to remove existing destination file $outFile: $!";
+if (not $firstFile) {
+    die "Unable to find a file with the specified extension $opts->{out_ext}\n";
 }
 
-copy $firstFile, $outFile or die "Unable to copy the first $outputExt file $firstFile to $outFile: $!";
+if (-f $opts->{out}) {
+    unlink $opts->{out} or die "Unable to remove existing destination file $opts->{out}: $!";
+}
+
+
+# Copy the first file to the destination --out file
+copy $firstFile, $opts->{out} or die "Unable to copy the first $opts->{out_ext} file $firstFile to $opts->{out}: $!";
 
 rmtree $tempDir or die "Unable to remove temp dir: $tempDir: $!";
 
 
-sub wanted {
-    if (not $firstFile and $_ =~ /\.$outputExt$/i) {
-        $firstFile = $File::Find::name;
-    }
-}
 
+
+
+
+
+
+
+#
+# isZip
+#
+# Checks if the given file is a zip file by looking for the magic number.
+#
+# Parameters:
+#    $file - path to input (presumably) zip file
+#
+# Returns:
+#    non-zero if the first four bytes match the zip magic number,
+#    zero otherwise (e.g. not a zip file)
+#
 sub isZip {
     my $file = shift;
     open my $fh, "<", $file or die "Unable to check $file for zip: $!";
@@ -78,6 +90,30 @@ sub isZip {
     return $num =~ m/^[PK\003\004]/;
 }
 
+
+sub validateAndProcessOptions {
+
+    my $desc = "Extracts the first .xgmml (or specified extension) file in the input archive.";
+
+    my $optParser = new EFI::Options(app_name => $0, desc => $desc);
+
+    $optParser->addOption("in=s", 1, "path to zip file", OPT_FILE);
+    $optParser->addOption("out=s", 1, "path to output first xgmml file to", OPT_FILE);
+    $optParser->addOption("out-ext=s", 0, "file extension to look for (defaults to xgmml)", OPT_FILE);
+
+    if (not $optParser->parseOptions() or $optParser->wantHelp()) {
+        print $optParser->printHelp();
+        exit(not $optParser->wantHelp());
+    }
+
+    my $opts = $optParser->getOptions();
+
+    $opts->{out_ext} = "xgmml" if not $opts->{out_ext};
+
+    return $opts;
+}
+
+
 1;
 __END__
 
@@ -85,17 +121,18 @@ __END__
 
 =head2 NAME
 
-C<unzip_xgmml_file.pl> - unzips a compressed XGMML file
+unzip_xgmml_file.pl - unzips a compressed XGMML file
 
 =head2 SYNOPSIS
 
-    unzip_xgmml_file.pl --cluster-map <FILE> --seqid-source-map <FILE> --singletons <FILE>
-        --stats <FILE>
+    unzip_xgmml_file.pl --in <FILE> --out <FILE> [--out-ext <FILE_EXT>]
 
 =head2 DESCRIPTION
 
-C<unzip_xgmml_file.pl> uncompresses the zip file and extracts the first XGMML file
-(C<.xgmml> extension>) that is found. It uses the system C<unzip> command.
+B<unzip_xgmml_file.pl> uncompresses the zip file and extracts the first file matching the
+specified file extension by C<--out-ext>.  If C<--out-ext> is not specified then the first
+XGMML file (with C<.xgmml> extension) is extracted.  This script requires that the system
+have the B<unzip> program installed.
 
 =head3 Arguments
 
@@ -103,16 +140,16 @@ C<unzip_xgmml_file.pl> uncompresses the zip file and extracts the first XGMML fi
 
 =item C<--in>
 
-Path to a zip file
+Path to a zip file.
 
 =item C<--out>
 
-Path to the location where the XGMML file should be stored
+Path to the file where the XGMML file should be extracted to.  If a file at that path
+already exists it will be deleted.
 
 =item C<--out-ext>
 
-The file extension in the archive to look for (defaults to C<.xgmml>)
+The file extension in the archive to look for (defaults to C<.xgmml>).
 
 =back
-
 


### PR DESCRIPTION
The vast majority of this PR is changes to documentation with minor code updates.

Updated POD:
- Make module references **bold** not `code` (was inconsistent previously)
- Make function headings `code` (was inconsistent previously)
- Change references to "Example usage:" to "Example Usage"
- Wrap most long lines
- Script POD updated in some places

Documentation in `docs/` was updated based on POD updates.

Code updates:
- Fixed issue with EFI::Options that included validation errors (e.g. missing args) when user requested help via `--help` arg
- Made help check in scripts to be consistent (merged validation and help check)
- Added EFI::Options usage to unzip and append scripts
- Refactored unzip script for clarity
