### PR TITLE
Exit GND creation script if EFI database connection failed

### DIFF
--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -26,6 +26,12 @@ my $opts = validateAndProcessOptions(DEFAULT_NEIGHBORHOOD_SIZE);
 my $db = new EFI::Database(config => $opts->{config}, db_name => $opts->{db_name});
 my $dbh = $db->getHandle();
 die "Invalid database $opts->{db_name}" if not $dbh;
+if (not $dbh) {
+    die "Error connecting to database: " . $db->getError() . "\n";
+}
+
+
+
 
 my $idMap = parse_cluster_map_file($opts->{cluster_map});
 


### PR DESCRIPTION
Applied a minor update to reflect changes to pipeline scripts when EFI database connection failed.