### PR TITLE
145 missing input parameters for the gnt.nf pipeline

### DIFF
--- a/bin/create_gnd_nextflow_params.py
+++ b/bin/create_gnd_nextflow_params.py
@@ -50,12 +50,13 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(cluster_id_map, efi_config, efi_db, output_dir, job_id, nextflow_config=None):
+def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, job_id, nextflow_config=None):
     params = {
         "final_output_dir": output_dir,
         "cluster_id_map": cluster_id_map,
         "efi_config": efi_config,
-        "efi_db": efi_db
+        "efi_db": efi_db,
+        "nb_size": nb_size
     }
     params_file = os.path.join(output_dir, shared_args.PARAMS_NAME)
     with open(params_file, "w") as f:

--- a/bin/create_gnd_nextflow_params.py
+++ b/bin/create_gnd_nextflow_params.py
@@ -14,6 +14,7 @@ def add_args(parser: argparse.ArgumentParser):
     Add arguments for GND pipeline to ``parser``
     """
     parser.add_argument("--cluster-id-map", required=True, type=str, help="The mapping of cluster numbers to IDs in the cluster for the GNDs")
+    parser.add_argument("--nb-size", type=int, required=False, default=20, help="Optional number of neighbors on the left and right of the input IDs to include in the analysis, an integer > 0.")
     shared_args.add_args(parser)
 
 def check_args(args: argparse.Namespace) -> argparse.Namespace:
@@ -33,6 +34,10 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"SSN Input file '{args.cluster_id_map}' does not exist")
         fail = True
     
+    if args.nb_size < 0 or args.nb_size > 20:
+        print(f"Neighborhood size (--nb-size) was given a bad value ({args.nb_size}).")
+        fail = True
+
     if fail:
         print("Failed to render params template")
         exit(1)

--- a/bin/create_gnd_nextflow_params.py
+++ b/bin/create_gnd_nextflow_params.py
@@ -34,8 +34,8 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"SSN Input file '{args.cluster_id_map}' does not exist")
         fail = True
     
-    if args.nb_size < 0 or args.nb_size > 20:
-        print(f"Neighborhood size (--nb-size) was given a bad value ({args.nb_size}).")
+    if args.nb_size < 1 or args.nb_size > 20:
+        print(f"Invalid value for --nb-size ({args.nb_size}).")
         fail = True
 
     if fail:

--- a/bin/create_gnd_nextflow_params.py
+++ b/bin/create_gnd_nextflow_params.py
@@ -14,7 +14,7 @@ def add_args(parser: argparse.ArgumentParser):
     Add arguments for GND pipeline to ``parser``
     """
     parser.add_argument("--cluster-id-map", required=True, type=str, help="The mapping of cluster numbers to IDs in the cluster for the GNDs")
-    parser.add_argument("--nb-size", type=int, required=False, default=20, help="Optional number of neighbors on the left and right of the input IDs to include in the analysis, an integer > 0.")
+    parser.add_argument("--nb-size", type=int, required=False, default=20, help="Optional number of neighbors on the left and right of the input IDs to include in the analysis, an integer > 0 and <= 20.")
     shared_args.add_args(parser)
 
 def check_args(args: argparse.Namespace) -> argparse.Namespace:

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -40,12 +40,12 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"FASTA database '{args.fasta_db}' not found")
         fail = True
 
-    if args.nb_size < 0 or args.nb_size > 20:
-        print(f"Neighborhood size (--nb-size) was given a bad value ({args.nb_size}).")
+    if args.nb_size < 1 or args.nb_size > 20:
+        print(f"Invalid value for --nb-size ({args.nb_size}).")
         fail = True
 
     if args.cooc_threshold < 0 or args.cooc_threshold > 1:
-        print(f"Co-occurrence threshold (--cooc-thresold) was given a bad value ({args.cooc_threshold}).")
+        print(f"Invalid value for --cooc-threshold ({args.cooc_threshold}).")
         fail = True
 
     if fail:

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -15,7 +15,7 @@ def add_args(parser: argparse.ArgumentParser):
     """
     parser.add_argument("--ssn-input", required=True, type=str, help="The SSN file to color and compute GNNs for, XGMML or zipped XGMML")
     parser.add_argument("--fasta-db", type=str, required=True, help="FASTA file or BLAST database to retrieve sequences from")
-    parser.add_argument("--nb-size", type=int, required=False, default=20, help="Optional number of neighbors on the left and right of the input IDs to include in the analysis, an integer > 0.")
+    parser.add_argument("--nb-size", type=int, required=False, default=20, help="Optional number of neighbors on the left and right of the input IDs to include in the analysis, an integer > 0 and <= 20.")
     parser.add_argument("--cooc-threshold", type=float, required=False, default=0.20, help="Optional co-occurrence threshold to use for computing the Pfam hubs, a real number >= 0 and <= 1.")
     shared_args.add_args(parser)
 

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -15,6 +15,8 @@ def add_args(parser: argparse.ArgumentParser):
     """
     parser.add_argument("--ssn-input", required=True, type=str, help="The SSN file to color and compute GNNs for, XGMML or zipped XGMML")
     parser.add_argument("--fasta-db", type=str, required=True, help="FASTA file or BLAST database to retrieve sequences from")
+    parser.add_argument("--nb-size", type=int, required=False, default=20, help="Optional number of neighbors on the left and right of the input IDs to include in the analysis, an integer > 0.")
+    parser.add_argument("--cooc-threshold", type=float, required=False, default=0.20, help="Optional co-occurrence threshold to use for computing the Pfam hubs, a real number >= 0 and <= 1.")
     shared_args.add_args(parser)
 
 def check_args(args: argparse.Namespace) -> argparse.Namespace:
@@ -38,6 +40,14 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"FASTA database '{args.fasta_db}' not found")
         fail = True
 
+    if args.nb_size < 0 or args.nb_size > 20:
+        print(f"Neighborhood size (--nb-size) was given a bad value ({args.nb_size}).")
+        fail = True
+
+    if args.nb_size < 0 or args.nb_size > 1:
+        print(f"Co-occurrence threshold (--cooc-thresold) was given a bad value ({args.cooc_threshold}).")
+        fail = True
+
     if fail:
         print("Failed to render params template")
         exit(1)
@@ -51,13 +61,15 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, job_id, nextflow_config=None):
+def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threhsold, output_dir, job_id, nextflow_config=None):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,
         "efi_config": efi_config,
         "efi_db": efi_db,
-        "fasta_db": fasta_db
+        "fasta_db": fasta_db,
+        "nb_size": nb_size,
+        "cooc_threshold": cooc_threshold
     }
     params_file = os.path.join(output_dir, shared_args.PARAMS_NAME)
     with open(params_file, "w") as f:

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -61,7 +61,7 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threhsold, output_dir, job_id, nextflow_config=None):
+def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threshold, output_dir, job_id, nextflow_config=None):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -44,7 +44,7 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"Neighborhood size (--nb-size) was given a bad value ({args.nb_size}).")
         fail = True
 
-    if args.nb_size < 0 or args.nb_size > 1:
+    if args.cooc_threshold < 0 or args.cooc_threshold > 1:
         print(f"Co-occurrence threshold (--cooc-thresold) was given a bad value ({args.cooc_threshold}).")
         fail = True
 

--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -36,7 +36,7 @@ if (not $dbh) {
 my $idMap = parse_cluster_map_file($opts->{cluster_map});
 
 my $gntAnno = new EFI::GNT::Annotations(dbh => $dbh);
-my $gnn = new EFI::GNT::GNN(dbh => $dbh, seq_cluster_id_map => $idMap, gnt_anno => $gntAnno);
+my $gnn = new EFI::GNT::GNN(dbh => $dbh, seq_cluster_id_map => $idMap, gnt_anno => $gntAnno, neighborhood_size => $opts->{nb_size});
 $gnn->retrieveClusterData();
 
 my $gnd = new EFI::GNT::GND();
@@ -52,7 +52,7 @@ sub validateAndProcessOptions {
 
     $optParser->addOption("cluster-map=s", 1, "path to a file mapping sequence ID to cluster number", OPT_FILE);
     $optParser->addOption("gnd=s", 1, "path to the output GND file", OPT_FILE);
-    $optParser->addOption("nb-size=i", 0, "neighborhood size (number of sequences to retrieve on either side of query", OPT_VALUE, $defaultNbSize);
+    $optParser->addOption("nb-size=i", 0, "neighborhood size (number of sequences) to retrieve on either side of query (> 0 and <= 20)", OPT_VALUE, $defaultNbSize);
     $optParser->addOption("config=s", 1, "path to the config file for database connection", OPT_FILE);
     $optParser->addOption("db-name=s", 1, "name of the EFI database to connect to for retrieving UniRef sequences");
 

--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -103,7 +103,7 @@ to visualize genome neighborhood diagrams (GNDs).
 =item C<--nb-size>
 
 Optional number of neighbors on the left and right of the input IDs to
-include in the analysis, an integer > 0.
+include in the analysis, an integer > 0 and <= 20.
 
 =item C<--config>
 

--- a/pipelines/gnd/gnd.nf
+++ b/pipelines/gnd/gnd.nf
@@ -8,7 +8,10 @@ process create_gnd {
 
     """
     perl $projectDir/create_gnd.pl \
-        --config ${params.efi_config} --db-name ${params.efi_db} --cluster-map $cluster_id_map \
+        --config ${params.efi_config} \
+        --db-name ${params.efi_db} \
+        --cluster-map $cluster_id_map \
+        --nb-size ${params.nb_size} \
         --gnd gnd.sqlite
     """
 }

--- a/pipelines/gnt/create_gnns.pl
+++ b/pipelines/gnt/create_gnns.pl
@@ -40,7 +40,7 @@ if (not $dbh) {
 my $idMap = parse_cluster_map_file($opts->{cluster_map});
 
 my $gntAnno = new EFI::GNT::Annotations(dbh => $dbh);
-my $gnn = new EFI::GNT::GNN(dbh => $dbh, seq_cluster_id_map => $idMap, gnt_anno => $gntAnno);
+my $gnn = new EFI::GNT::GNN(dbh => $dbh, seq_cluster_id_map => $idMap, gnt_anno => $gntAnno, neighborhood_size => $opts->{nb_size});
 $gnn->retrieveClusterData();
 
 # Compute the family hub data that is used to generate the Pfam and cluster
@@ -83,8 +83,8 @@ sub validateAndProcessOptions {
     $optParser->addOption("hub-count=s", 0, "path to the output hub count table file", OPT_FILE);
     $optParser->addOption("nb-pfam-list-dir=s", 0, "path to an output directory containing files for each Pfam hub", OPT_DIR_PATH);
     $optParser->addOption("no-context=s", 0, "path to an output file to save a list of input IDs that didn't have an ENA entry or didn't have neighbors", OPT_FILE);
-    $optParser->addOption("nb-size=i", 0, "neighborhood size (number of sequences to retrieve on either side of query)", OPT_VALUE, $defaultNbSize);
-    $optParser->addOption("cooc-threshold=f", 0, "Cooccurrence threshold (>= 0.0 and <= 1.0)", OPT_VALUE, $defaultCoocThreshold);
+    $optParser->addOption("nb-size=i", 0, "neighborhood size (number of sequences) to retrieve on either side of query (> 0 and <= 20)", OPT_VALUE, $defaultNbSize);
+    $optParser->addOption("cooc-threshold=f", 0, "cooccurrence threshold (>= 0.0 and <= 1.0)", OPT_VALUE, $defaultCoocThreshold);
     $optParser->addOption("config=s", 1, "path to the config file for database connection", OPT_FILE);
     $optParser->addOption("db-name=s", 1, "name of the EFI database to connect to for retrieving UniRef sequences");
 

--- a/pipelines/gnt/create_gnns.pl
+++ b/pipelines/gnt/create_gnns.pl
@@ -83,7 +83,7 @@ sub validateAndProcessOptions {
     $optParser->addOption("hub-count=s", 0, "path to the output hub count table file", OPT_FILE);
     $optParser->addOption("nb-pfam-list-dir=s", 0, "path to an output directory containing files for each Pfam hub", OPT_DIR_PATH);
     $optParser->addOption("no-context=s", 0, "path to an output file to save a list of input IDs that didn't have an ENA entry or didn't have neighbors", OPT_FILE);
-    $optParser->addOption("nb-size=i", 0, "neighborhood size (number of sequences to retrieve on either side of query", OPT_VALUE, $defaultNbSize);
+    $optParser->addOption("nb-size=i", 0, "neighborhood size (number of sequences to retrieve on either side of query)", OPT_VALUE, $defaultNbSize);
     $optParser->addOption("cooc-threshold=f", 0, "Cooccurrence threshold (>= 0.0 and <= 1.0)", OPT_VALUE, $defaultCoocThreshold);
     $optParser->addOption("config=s", 1, "path to the config file for database connection", OPT_FILE);
     $optParser->addOption("db-name=s", 1, "name of the EFI database to connect to for retrieving UniRef sequences");

--- a/pipelines/gnt/create_gnns.pl
+++ b/pipelines/gnt/create_gnns.pl
@@ -178,7 +178,7 @@ ENA data or without neighbors.
 =item C<--nb-size>
 
 Optional number of neighbors on the left and right of the input IDs to
-include in the analysis, an integer > 0.
+include in the analysis, an integer > 0 and <= 20.
 
 =item C<--cooc-threshold>
 

--- a/pipelines/gnt/gnt.nf
+++ b/pipelines/gnt/gnt.nf
@@ -25,10 +25,18 @@ process create_gnns {
     cat ${cluster_id_map} > \$id_map_file
     awk '{if(NR>1)print}' ${singletons} >> \$id_map_file
     perl $projectDir/create_gnns.pl \
-        --config ${params.efi_config} --db-name ${params.efi_db} --cluster-map \$id_map_file \
-        --cluster-gnn cluster_gnn.xgmml --pfam-gnn pfam_gnn.xgmml \
-        --hub-count hub_count.txt --cooc-table cooc_table.txt --no-context nomatches_noneighbors.txt \
-        --nb-pfam-list-dir nb_pfam --gnd gnd.sqlite
+        --cluster-map \$id_map_file \
+        --cluster-gnn cluster_gnn.xgmml \
+        --pfam-gnn pfam_gnn.xgmml \
+        --gnd gnd.sqlite \
+        --cooc-table cooc_table.txt \
+        --hub-count hub_count.txt \
+        --nb-pfam-list-dir nb_pfam \
+        --no-context nomatches_noneighbors.txt \
+        --nb-size ${params.nb_size} \
+        --cooc-threshold ${params.cooc_threshold} \
+        --config ${params.efi_config} \
+        --db-name ${params.efi_db}
     """
 }
 


### PR DESCRIPTION
Implement the `nb_size` and `cooc_threshold` input parameters for both the gnt.nf and gnd.nf code. Also, specifically use their input arguments in the perl backend codes.  