### PR TITLE
149 suspected issues with pb spro config files

### DIFF
--- a/conf/colorssn/pbspro.config
+++ b/conf/colorssn/pbspro.config
@@ -12,11 +12,4 @@ process {
     executor = 'local'
     cpus = 1
     memory = 8.GB
-
-    withName: cluster_gnn {
-        executor = 'pbspro'
-        cpus = 1
-        memory = 32.GB
-        time = 8.h
-    }
 }

--- a/conf/colorssn/slurm.config
+++ b/conf/colorssn/slurm.config
@@ -13,11 +13,4 @@ process {
     executor = 'local'
     cpus = 1
     memory = 8.GB
-
-    withName: cluster_gnn {
-        executor = 'slurm'
-        queue = 'efi'
-        cpus = 1
-        memory = 32.GB
-    }
 }

--- a/conf/gnd/pbspro.config
+++ b/conf/gnd/pbspro.config
@@ -9,6 +9,7 @@ executor {
 }
 
 process {
+    executor = 'local'
     cpus = 1
     memory = 10.GB
 }

--- a/conf/gnt/pbspro.config
+++ b/conf/gnt/pbspro.config
@@ -9,6 +9,7 @@ executor {
 }
 
 process {
+    executor = 'local'
     cpus = 1
     memory = 10.GB
 }


### PR DESCRIPTION
Minor clean ups of config files. 

- `executor = "local"` line led to the gnt and gnd tests to run successfully on NCSS HPC machine. 
- `cluster_gnn` process config block is unnecessary since no such process exists (AFAIK). 