### PR TITLE
Refactor use of EFI::Sequence::Type constants

### DIFF
--- a/lib/EFI/GNT/GND/Schema.pm
+++ b/lib/EFI/GNT/GND/Schema.pm
@@ -4,7 +4,11 @@ package EFI::GNT::GND::Schema;
 use strict;
 use warnings;
 
-use DBI;
+use Cwd qw(abs_path);
+use File::Basename qw(dirname);
+use lib dirname(abs_path(__FILE__)) . "/../../..";
+
+use EFI::Sequence::Type qw(:types);
 
 use constant SORT_KEY => "sort_key";
 use constant QUERY_KEY => "query_key"; # links the neighbors to corresponding query sequences
@@ -12,17 +16,12 @@ use constant LEGACY_QUERY_KEY => "gene_key"; # legacy column name, replaced in t
 use constant QUERY_TABLE => "attributes";
 use constant NEIGHBOR_TABLE => "neighbors";
 
+use constant UNIREF90_TABLE => "uniref90";
+use constant UNIREF50_TABLE => "uniref50";
+
 use Exporter qw(import);
 our %EXPORT_TAGS = (schema => ['SORT_KEY', 'QUERY_KEY', 'QUERY_TABLE', 'NEIGHBOR_TABLE', 'LEGACY_QUERY_KEY']);
 Exporter::export_ok_tags('schema');
-
-# These should come from EFI::Sequence::Type (which exists in a branch yet to be merged)
-use constant SEQ_UNIPROT => "uniprot";
-use constant SEQ_UNIREF50 => "uniref50";
-use constant SEQ_UNIREF90 => "uniref90";
-
-use constant UNIREF90_TABLE => "uniref90";
-use constant UNIREF50_TABLE => "uniref50";
 
 
 sub new {

--- a/lib/EFI/Import/Config/Filter.pm
+++ b/lib/EFI/Import/Config/Filter.pm
@@ -11,7 +11,7 @@ use parent qw(EFI::Import::Config);
 
 use EFI::Import::Config::Defaults qw(get_default_path);
 use EFI::Options;
-use EFI::Sequence::Type;
+use EFI::Sequence::Type qw(get_sequence_version);
 
 
 

--- a/lib/EFI/Import/Config/Source.pm
+++ b/lib/EFI/Import/Config/Source.pm
@@ -12,7 +12,7 @@ use parent qw(EFI::Import::Config);
 use EFI::Import::Sources;
 use EFI::Import::Config::Defaults qw(get_default_path);
 use EFI::Options;
-use EFI::Sequence::Type;
+use EFI::Sequence::Type qw(get_sequence_version);
 
 
 sub new {

--- a/lib/EFI/Import/Source.pm
+++ b/lib/EFI/Import/Source.pm
@@ -10,9 +10,9 @@ use Cwd qw(abs_path);
 use File::Basename qw(dirname);
 use lib dirname(abs_path(__FILE__)) . "/../../";
 
-use EFI::Annotations::Fields ':all';
+use EFI::Annotations::Fields qw(:all);
 use EFI::Import::Util;
-use EFI::Sequence::Type;
+use EFI::Sequence::Type qw(:types);
 
 
 our $TYPE_NAME = "";

--- a/lib/EFI/Import/Source/Family.pm
+++ b/lib/EFI/Import/Source/Family.pm
@@ -10,8 +10,8 @@ use lib dirname(abs_path(__FILE__)) . "/../../../";
 use lib dirname(abs_path(__FILE__)) . "/../../../../../../../lib"; # Global libs
 use parent qw(EFI::Import::Source);
 
-use EFI::Annotations::Fields ':source';
-use EFI::Sequence::Type;
+use EFI::Annotations::Fields qw(:source);
+use EFI::Sequence::Type qw(:types);
 
 use Exporter qw(import);
 use constant FAMILY_SOURCE_NAME => "family";

--- a/lib/EFI/Sequence.pm
+++ b/lib/EFI/Sequence.pm
@@ -132,7 +132,6 @@ B<EFI::Sequence> - Perl module that represents a sequence
 =head2 SYNOPSIS
 
     use EFI::Sequence;
-    use EFI::Sequence::Type;
     use EFI::Annotations::Fields qw(:source :annotations);
 
     my $id = "A0M8S7";

--- a/lib/EFI/Sequence/Collection.pm
+++ b/lib/EFI/Sequence/Collection.pm
@@ -10,7 +10,7 @@ use lib dirname(abs_path(__FILE__)) . "/../../";
 
 use EFI::Annotations::Fields qw(:annotations);
 use EFI::Sequence;
-use EFI::Sequence::Type;
+use EFI::Sequence::Type qw(:types);
 
 
 sub new {
@@ -441,7 +441,7 @@ B<EFI::Sequence::Collection> - Perl module that represents a collection of seque
 
     use EFI::Sequence;
     use EFI::Sequence::Collection;
-    use EFI::Sequence::Type;
+    use EFI::Sequence::Type qw(:types);
 
     my $seqSource = SEQ_UNIREF50;
     my $mdFile = "sequence_metadata.tab";

--- a/lib/EFI/Sequence/Type.pm
+++ b/lib/EFI/Sequence/Type.pm
@@ -12,8 +12,9 @@ use constant SEQ_UNIREF50 => "uniref50";
 use constant SEQ_UNIREF90 => "uniref90";
 
 
-our @EXPORT = qw(SEQ_UNIPROT SEQ_UNIREF50 SEQ_UNIREF90 get_sequence_version);
-our @EXPORT_OK = qw(is_unknown_sequence);
+our @EXPORT_OK = qw(is_unknown_sequence SEQ_UNIPROT SEQ_UNIREF50 SEQ_UNIREF90 get_sequence_version);
+our %EXPORT_TAGS = (types => ['SEQ_UNIPROT', 'SEQ_UNIREF50', 'SEQ_UNIREF90']);
+Exporter::export_ok_tags('types');
 
 
 sub get_sequence_version {

--- a/pipelines/est/import/filter_ids.pl
+++ b/pipelines/est/import/filter_ids.pl
@@ -15,7 +15,6 @@ use EFI::Import::Filter::Taxonomy;
 use EFI::Import::Statistics;
 use EFI::Options;
 use EFI::Sequence::Collection;
-use EFI::Sequence::Type;
 
 
 my $defaultPredefTaxFiltFileName = "assets/predefined_taxonomy_filters.yml";

--- a/pipelines/est/import/get_sequence_ids.pl
+++ b/pipelines/est/import/get_sequence_ids.pl
@@ -14,7 +14,6 @@ use EFI::Import::Source::Family qw(FAMILY_SOURCE_NAME);
 use EFI::Import::Sources;
 use EFI::Import::Statistics;
 use EFI::Sequence::Collection;
-use EFI::Sequence::Type;
 
 
 my $logger = new EFI::Import::Logger();

--- a/pipelines/est/import/get_sunburst_data.pl
+++ b/pipelines/est/import/get_sunburst_data.pl
@@ -10,7 +10,6 @@ use lib "$FindBin::Bin/../../../lib";
 use EFI::Database;
 use EFI::Import::Config::Sunburst;
 use EFI::Sequence::Collection;
-use EFI::Sequence::Type;
 use EFI::Sunburst::Data;
 
 


### PR DESCRIPTION
- Require use of SEQ_UNI* constants by explicit import of :types tag
- Use EFI::Sequence::Type::SEQ_UNI* constants in GND::Schema instead of internally-defined constants