### PR TITLE
Sequence BLAST - retrieval options differentiated from all-to-all options

### DIFF
--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -34,7 +34,7 @@ def add_args(parser: argparse.ArgumentParser):
     # option A: Sequence BLAST
     blast_parser = subparsers.add_parser("blast", help="Import sequences using the single sequence BLAST option", parents=[common_parser]).add_argument_group("Sequence BLAST Options")
     blast_parser.add_argument("--blast-query-file", required=True, type=str, help="The file containing a single sequence to use for the initial BLAST to obtain sequences")
-    blast_parser.add_argument("--import-blast-fasta-db", type=str, help="FASTA file or BLAST database to use for the initial import to find sequences; must be set if the --sequence-version is uniref50 or uniref90")
+    blast_parser.add_argument("--import-blast-fasta-db", type=str, help="FASTA file or BLAST database to use for the initial import to find sequences; must be set if the --sequence-version is uniref50 or uniref90; defaults to the same as --fasta-db.")
     blast_parser.add_argument("--import-blast-num-matches", default=1000, type=int, help="Maximum number of matches returned by BLAST when retrieving sequences")
     blast_parser.add_argument("--import-blast-evalue", default="1e-5", help="Cutoff e-value to use in the BLAST sequence alignment when retrieving sequences")
 

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -21,7 +21,7 @@ def add_args(parser: argparse.ArgumentParser):
     common_parser.add_argument("--accession-shards", default=16, type=int, help="Number of files to split Accessions list into. File is split so that sequence retrieval can be parallelized")
     common_parser.add_argument("--fasta-db", type=str, required=True, help="FASTA file or BLAST database to retrieve sequences from")
     common_parser.add_argument("--multiplex", action="store_true", help="Use CD-HIT to reduce the number of sequences used in analysis")
-    common_parser.add_argument("--blast-num-matches", default=250, type=int, help="Number of matches BLAST should return; dev site only?")
+    common_parser.add_argument("--blast-num-matches", default=250, type=int, help="Number of matches BLAST should return")
     common_parser.add_argument("--blast-evalue", default="1e-5", help="Cutoff E value to use in all-by-all BLAST")
     common_parser.add_argument("--sequence-version", type=str, default="uniprot", choices=["uniprot", "uniref90", "uniref50"])
     common_parser.add_argument("--filter", action="append", type=str, help="Filter sequences, use multiple times to indicate filter types")

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -19,9 +19,9 @@ def add_args(parser: argparse.ArgumentParser):
     common_parser.add_argument("--duckdb-threads", default=1, type=int, help="Number of threads DuckDB can use. More threads means higher memory usage")
     common_parser.add_argument("--fasta-shards", default=128, type=int, help="Number of files to split FASTA into. File is split so that BLAST can be parallelized")
     common_parser.add_argument("--accession-shards", default=16, type=int, help="Number of files to split Accessions list into. File is split so that sequence retrieval can be parallelized")
-    common_parser.add_argument("--blast-matches", default=250, type=int, help="Number of matches BLAST should return")
     common_parser.add_argument("--fasta-db", type=str, required=True, help="FASTA file or BLAST database to retrieve sequences from")
     common_parser.add_argument("--multiplex", action="store_true", help="Use CD-HIT to reduce the number of sequences used in analysis")
+    common_parser.add_argument("--blast-num-matches", default=250, type=int, help="Number of matches BLAST should return; dev site only?")
     common_parser.add_argument("--blast-evalue", default="1e-5", help="Cutoff E value to use in all-by-all BLAST")
     common_parser.add_argument("--sequence-version", type=str, default="uniprot", choices=["uniprot", "uniref90", "uniref50"])
     common_parser.add_argument("--filter", action="append", type=str, help="Filter sequences, use multiple times to indicate filter types")
@@ -33,8 +33,10 @@ def add_args(parser: argparse.ArgumentParser):
     
     # option A: Sequence BLAST
     blast_parser = subparsers.add_parser("blast", help="Import sequences using the single sequence BLAST option", parents=[common_parser]).add_argument_group("Sequence BLAST Options")
-    blast_parser.add_argument("--blast-query-file", required=True, type=str, help="The file containing a single sequence to use for the initial BLAST to obtain sequences")
+    blast_parser.add_argument("--import-blast-query-file", required=True, type=str, help="The file containing a single sequence to use for the initial BLAST to obtain sequences")
     blast_parser.add_argument("--import-blast-fasta-db", type=str, help="FASTA file or BLAST database to use for the initial import to find sequences; must be set if the --sequence-version is uniref50 or uniref90")
+    blast_parser.add_argument("--import-blast-num-matches", default=1000, type=int, help="Maximum number of matches BLAST should return for the input query sequence")
+    blast_parser.add_argument("--import-blast-evalue", default="1e-5", help="Cutoff e-value to use in the input BLAST sequence alignment.")
 
     # option B: Family
     family_parser = subparsers.add_parser("family", help="Import sequences using the family option", parents=[common_parser]).add_argument_group("Family Options")
@@ -68,11 +70,11 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
 
     # import mode-specific tests
     if args.import_mode == "blast":
-        if not os.path.exists(args.blast_query_file):
-            print(f"BLAST query file '{args.blast_query_file}' does not exist")
+        if not os.path.exists(args.import_blast_query_file):
+            print(f"BLAST query file '{args.import_blast_query_file}' does not exist")
             fail = True
         else:
-            args.blast_query_file = os.path.abspath(args.blast_query_file)
+            args.import_blast_query_file = os.path.abspath(args.import_blast_query_file)
         if args.import_blast_fasta_db is not None:
             # Use the UniRef database for the BLAST
             args.import_blast_fasta_db = os.path.abspath(args.import_blast_fasta_db)
@@ -121,8 +123,10 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
                   sequence_filter=None,
                   fasta_file=None,
                   accessions_file=None,
-                  blast_query_file=None,
+                  import_blast_query_file=None,
                   import_blast_fasta_db=None,
+                  import_blast_num_matches=None,
+                  import_blast_evalue=None,
                   nextflow_config=None
                   ):
     params = {
@@ -131,7 +135,6 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
         "duckdb_threads": duckdb_threads,
         "num_fasta_shards": fasta_shards,
         "num_accession_shards": accession_shards,
-        "num_blast_matches": blast_matches,
         "job_id": job_id,
         "efi_config": efi_config,
         "fasta_db": fasta_db,
@@ -139,13 +142,16 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
         "import_mode": import_mode,
         "filter": sequence_filter,
         "multiplex": multiplex,
+        "blast_num_matches": blast_matches,
         "blast_evalue": blast_evalue,
         "sequence_version": sequence_version
     }
     if import_mode == "blast":
         params |= {
-            "blast_query_file": blast_query_file,
-            "import_blast_fasta_db": import_blast_fasta_db
+            "import_blast_query_file": import_blast_query_file,
+            "import_blast_fasta_db": import_blast_fasta_db,
+            "import_blast_num_matches": import_blast_num_matches,
+            "import_blast_evalue": import_blast_evalue
         }
     elif import_mode == "fasta":
         params |= {

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -21,7 +21,7 @@ def add_args(parser: argparse.ArgumentParser):
     common_parser.add_argument("--accession-shards", default=16, type=int, help="Number of files to split Accessions list into. File is split so that sequence retrieval can be parallelized")
     common_parser.add_argument("--fasta-db", type=str, required=True, help="FASTA file or BLAST database to retrieve sequences from")
     common_parser.add_argument("--multiplex", action="store_true", help="Use CD-HIT to reduce the number of sequences used in analysis")
-    common_parser.add_argument("--blast-num-matches", default=250, type=int, help="Number of matches BLAST should return")
+    common_parser.add_argument("--blast-num-matches", default=250, type=int, help="Maximum number of matches returned by BLAST for the all-by-all computation")
     common_parser.add_argument("--blast-evalue", default="1e-5", help="Cutoff E value to use in all-by-all BLAST")
     common_parser.add_argument("--sequence-version", type=str, default="uniprot", choices=["uniprot", "uniref90", "uniref50"])
     common_parser.add_argument("--filter", action="append", type=str, help="Filter sequences, use multiple times to indicate filter types")
@@ -33,10 +33,10 @@ def add_args(parser: argparse.ArgumentParser):
     
     # option A: Sequence BLAST
     blast_parser = subparsers.add_parser("blast", help="Import sequences using the single sequence BLAST option", parents=[common_parser]).add_argument_group("Sequence BLAST Options")
-    blast_parser.add_argument("--import-blast-query-file", required=True, type=str, help="The file containing a single sequence to use for the initial BLAST to obtain sequences")
+    blast_parser.add_argument("--blast-query-file", required=True, type=str, help="The file containing a single sequence to use for the initial BLAST to obtain sequences")
     blast_parser.add_argument("--import-blast-fasta-db", type=str, help="FASTA file or BLAST database to use for the initial import to find sequences; must be set if the --sequence-version is uniref50 or uniref90")
-    blast_parser.add_argument("--import-blast-num-matches", default=1000, type=int, help="Maximum number of matches BLAST should return for the input query sequence")
-    blast_parser.add_argument("--import-blast-evalue", default="1e-5", help="Cutoff e-value to use in the input BLAST sequence alignment.")
+    blast_parser.add_argument("--import-blast-num-matches", default=1000, type=int, help="Maximum number of matches returned by BLAST when retrieving sequences")
+    blast_parser.add_argument("--import-blast-evalue", default="1e-5", help="Cutoff e-value to use in the BLAST sequence alignment when retrieving sequences")
 
     # option B: Family
     family_parser = subparsers.add_parser("family", help="Import sequences using the family option", parents=[common_parser]).add_argument_group("Family Options")
@@ -70,11 +70,11 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
 
     # import mode-specific tests
     if args.import_mode == "blast":
-        if not os.path.exists(args.import_blast_query_file):
-            print(f"BLAST query file '{args.import_blast_query_file}' does not exist")
+        if not os.path.exists(args.blast_query_file):
+            print(f"BLAST query file '{args.blast_query_file}' does not exist")
             fail = True
         else:
-            args.import_blast_query_file = os.path.abspath(args.import_blast_query_file)
+            args.blast_query_file = os.path.abspath(args.blast_query_file)
         if args.import_blast_fasta_db is not None:
             # Use the UniRef database for the BLAST
             args.import_blast_fasta_db = os.path.abspath(args.import_blast_fasta_db)
@@ -123,7 +123,7 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
                   sequence_filter=None,
                   fasta_file=None,
                   accessions_file=None,
-                  import_blast_query_file=None,
+                  blast_query_file=None,
                   import_blast_fasta_db=None,
                   import_blast_num_matches=None,
                   import_blast_evalue=None,
@@ -148,7 +148,7 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
     }
     if import_mode == "blast":
         params |= {
-            "import_blast_query_file": import_blast_query_file,
+            "blast_query_file": blast_query_file,
             "import_blast_fasta_db": import_blast_fasta_db,
             "import_blast_num_matches": import_blast_num_matches,
             "import_blast_evalue": import_blast_evalue

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -116,7 +116,7 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards, accession_shards, blast_matches, job_id,
+def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards, accession_shards, blast_num_matches, job_id,
                   efi_config, fasta_db, efi_db, multiplex, blast_evalue,
                   import_mode, sequence_version,
                   families=None,
@@ -142,7 +142,7 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
         "import_mode": import_mode,
         "filter": sequence_filter,
         "multiplex": multiplex,
-        "blast_num_matches": blast_matches,
+        "blast_num_matches": blast_num_matches,
         "blast_evalue": blast_evalue,
         "sequence_version": sequence_version
     }

--- a/docs/source/pipelines/est/index.rst
+++ b/docs/source/pipelines/est/index.rst
@@ -43,7 +43,7 @@ EST pipeline-specific arguments for the various modes are:
 
 * **blast** mode:
 
-  * ``--import-blast-query-file``: path to a file containing a single sequence.
+  * ``--blast-query-file``: path to a file containing a single sequence.
     [*required*]
 
   * ``--import-blast-fasta-db``: optional path to an alternative sequence

--- a/docs/source/pipelines/est/index.rst
+++ b/docs/source/pipelines/est/index.rst
@@ -43,11 +43,21 @@ EST pipeline-specific arguments for the various modes are:
 
 * **blast** mode:
 
-  * ``--blast-query-file``: path to a file containing a single sequence.
+  * ``--import-blast-query-file``: path to a file containing a single sequence.
     [*required*]
 
   * ``--import-blast-fasta-db``: optional path to an alternative sequence
     database, used when the ``--sequence-version`` option is provided.
+
+  * ``--import-blast-num-matches``: optional integer value used to set the
+    maximum number of sequence alignment matches returned from the initial
+    ``blastall`` call used to retrieve sequences to be further analyzed. 
+    Default value is 1000. 
+  
+  * ``--import-blast-evalue``: optional float value setting the threshold
+    e-value applied to the initial ``blastall`` call used to retrieve sequences
+    to be further analyzed. Default value is 1e-5. 
+    
 
 * **families** mode:
 
@@ -123,7 +133,7 @@ usage with ``--duckdb-memory-limit``.  DuckDB generally does a good job of
 swapping results to disk if it is memory constrained but some operations
 require some minimum amount of memory.  If these solutions did not solve the
 problem, try using the newest version of DuckDB (which may require manually
-building the docker image) or decreasing the number of ``--blast-matches``
+building the docker image) or decreasing the number of ``--blast-num-matches``
 which will reduce the total number of edges processed.  Multiplexing will also
 reduce the number of sequences analyzed and can help solve these errors.
 

--- a/pipelines/est/est.nf
+++ b/pipelines/est/est.nf
@@ -22,14 +22,14 @@ process get_source_ids {
     if (params.import_mode == "blast") {
         // blast_hits.tab is provided as an output to the user
         """
-        blastall -p blastp -i ${params.import_blast_query_file} -d ${params.import_blast_fasta_db} -m 8 -e ${params.import_blast_evalue} -b ${params.import_blast_num_matches} -o init_blast.out
+        blastall -p blastp -i ${params.blast_query_file} -d ${params.import_blast_fasta_db} -m 8 -e ${params.import_blast_evalue} -b ${params.import_blast_num_matches} -o init_blast.out
         if [[ -s init_blast.out ]]; then
             awk '! /^#/ {print \$2"\t"\$11}' init_blast.out | sort -k2nr > blast_hits.tab
         else
             echo "BLAST did not return any matches.  Verify that the sequence is a protein and not a nucleotide sequence."
             exit 1
         fi
-        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --blast-output init_blast.out --blast-query ${params.import_blast_query_file}
+        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --blast-output init_blast.out --blast-query ${params.blast_query_file}
         """
     } else if (params.import_mode == "accessions") {
         """
@@ -94,7 +94,7 @@ process cat_fasta_files {
     if (params.import_mode == "blast") {
         """
         $cat_cmd
-        perl $projectDir/import/append_blast_query.pl --blast-query-file ${params.import_blast_query_file} --output-sequence-file all_sequences.fasta
+        perl $projectDir/import/append_blast_query.pl --blast-query-file ${params.blast_query_file} --output-sequence-file all_sequences.fasta
         """
     } else {
         cat_cmd

--- a/pipelines/est/est.nf
+++ b/pipelines/est/est.nf
@@ -22,14 +22,14 @@ process get_source_ids {
     if (params.import_mode == "blast") {
         // blast_hits.tab is provided as an output to the user
         """
-        blastall -p blastp -i ${params.blast_query_file} -d ${params.import_blast_fasta_db} -m 8 -e ${params.blast_evalue} -b ${params.num_blast_matches} -o init_blast.out
+        blastall -p blastp -i ${params.import_blast_query_file} -d ${params.import_blast_fasta_db} -m 8 -e ${params.import_blast_evalue} -b ${params.import_blast_num_matches} -o init_blast.out
         if [[ -s init_blast.out ]]; then
             awk '! /^#/ {print \$2"\t"\$11}' init_blast.out | sort -k2nr > blast_hits.tab
         else
             echo "BLAST did not return any matches.  Verify that the sequence is a protein and not a nucleotide sequence."
             exit 1
         fi
-        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --blast-output init_blast.out --blast-query ${params.blast_query_file}
+        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --blast-output init_blast.out --blast-query ${params.import_blast_query_file}
         """
     } else if (params.import_mode == "accessions") {
         """
@@ -94,7 +94,7 @@ process cat_fasta_files {
     if (params.import_mode == "blast") {
         """
         $cat_cmd
-        perl $projectDir/import/append_blast_query.pl --blast-query-file ${params.blast_query_file} --output-sequence-file all_sequences.fasta
+        perl $projectDir/import/append_blast_query.pl --blast-query-file ${params.import_blast_query_file} --output-sequence-file all_sequences.fasta
         """
     } else {
         cat_cmd
@@ -145,7 +145,7 @@ process all_by_all_blast {
         path "${frac}.tab.sorted.parquet"
     """
     # run blast to get similarity metrics
-    blastall -p blastp -i $frac -d $blast_db_name -m 8 -e ${params.blast_evalue} -b ${params.num_blast_matches} -o ${frac}.tab
+    blastall -p blastp -i $frac -d $blast_db_name -m 8 -e ${params.blast_evalue} -b ${params.blast_num_matches} -o ${frac}.tab
 
     # transcode to parquet for speed, creates frac.tab.parquet
     python $projectDir/axa_blast/transcode_blast.py --blast-output ${frac}.tab

--- a/tests/modules/02a_est_blast.sh
+++ b/tests/modules/02a_est_blast.sh
@@ -11,7 +11,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-5
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $NXF_SSN_CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/02a_est_blast.sh
+++ b/tests/modules/02a_est_blast.sh
@@ -11,7 +11,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-5
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-5 --import-blast-fasta-db $EFI_DB_NAME
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $NXF_SSN_CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/02a_est_blast.sh
+++ b/tests/modules/02a_est_blast.sh
@@ -11,7 +11,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-5 --import-blast-fasta-db $EFI_DB_NAME
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-5
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $NXF_SSN_CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/02a_est_blast.sh
+++ b/tests/modules/02a_est_blast.sh
@@ -11,7 +11,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-5
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $NXF_SSN_CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/02i_est_blast_import_args.sh
+++ b/tests/modules/extended/02i_est_blast_import_args.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+TEST_RESULTS_DIR=$1
+CONFIG_FILE=$2
+NXF_EST_CONFIG_FILE="conf/est/$CONFIG_FILE"
+NXF_SSN_CONFIG_FILE="conf/generatessn/$CONFIG_FILE"
+
+self=$(basename "$0" .sh)
+OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
+
+rm -rf $OUTPUT_DIR
+
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $NXF_EST_CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-2 --import-blast-fasta-db $EFI_DB_NAME
+bash $OUTPUT_DIR/run_nextflow.sh
+
+./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --ssn-title test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $NXF_SSN_CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME
+bash $OUTPUT_DIR/ssn/run_nextflow.sh
+

--- a/tests/test_env.sh
+++ b/tests/test_env.sh
@@ -50,7 +50,7 @@ do
                         default database, and this option can be used to
                         connect tests to external, large BLAST databases used
                         in the full EFI toolset
-        --blast-import-db
+        --blast-import-fasta-db
                         path to a BLAST database that is used to determine which
                         IDs are to be used in the computation; if not specified
                         then the test UniRef50 database is used
@@ -84,7 +84,7 @@ do
 	elif [[ ${!index} == "--fasta-db" ]]; then
 		fasta_db="${!idx}"
 		echo "Using $fasta_db as the FASTA database path"
-	elif [[ ${!index} == "--blast-importfasta-db" ]]; then
+	elif [[ ${!index} == "--blast-import-fasta-db" ]]; then
 		blast_import_fasta_db="${!idx}"
 		echo "Using $blast_import_fasta_db as the UniRef BLAST import FASTA database path"
 	# manually specify the configuration file


### PR DESCRIPTION
This will close the immediate coding concerns about issues #126 and #127. The open questions about appropriate default values for all of those issues still stand (and can be turned into "question" issues). 

- [x] Implemented command line argument parameters for the `bin/create_est_nextflow_params.py` script for the Option A (Sequence BLAST) import mode, following a naming scheme `import_blast_*`. 
- [x] Moved other import mode-specific arguments to this same naming scheme. 
- [x] Mirrored the necessary `params.import_blast_*` naming in the est.nf script. 