### PR TITLE
169 support generic job script creation

### DIFF
--- a/bin/create_colorssn_nextflow_params.py
+++ b/bin/create_colorssn_nextflow_params.py
@@ -38,6 +38,9 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"FASTA database '{args.fasta_db}' not found")
         fail = True
 
+    if args.workflow_def is None:
+        args.workflow_def = os.path.abspath(NXF_SCRIPT)
+
     if fail:
         print("Failed to render params template")
         exit(1)
@@ -51,8 +54,7 @@ def create_parser() -> argparse.ArgumentParser:
     add_args(parser)
     return parser
 
-def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, job_id,
-        nextflow_config=None, templates_dir=None, template=None):
+def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, **kwargs: dict):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,
@@ -69,5 +71,5 @@ def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, job_id,
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
     params_file = render_params(**vars(args))
-    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
+    shared_args.save_run_script(args, workflow_def=args.workflow_def, params_file=params_file)
 

--- a/bin/create_colorssn_nextflow_params.py
+++ b/bin/create_colorssn_nextflow_params.py
@@ -52,7 +52,7 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, job_id,
-        nextflow_config=None, templates_dir=None, template=None, template_env=None):
+        nextflow_config=None, templates_dir=None, template=None):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,

--- a/bin/create_colorssn_nextflow_params.py
+++ b/bin/create_colorssn_nextflow_params.py
@@ -51,7 +51,8 @@ def create_parser() -> argparse.ArgumentParser:
     add_args(parser)
     return parser
 
-def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, job_id, nextflow_config=None):
+def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, job_id,
+        nextflow_config=None, templates_dir=None, template=None, template_env=None):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,
@@ -67,6 +68,6 @@ def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir, job_id, n
 
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
-    render_params(**vars(args))
-    shared_args.save_run_script(args, NXF_SCRIPT)
+    params_file = render_params(**vars(args))
+    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
 

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -123,7 +123,8 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
                   accessions_file=None,
                   blast_query_file=None,
                   import_blast_fasta_db=None,
-                  nextflow_config=None
+                  nextflow_config=None,
+                  templates_dir=None, template=None, template_env=None):
                   ):
     params = {
         "final_output_dir": output_dir,
@@ -169,6 +170,6 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
 
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
-    render_params(**vars(args))
-    shared_args.save_run_script(args, NXF_SCRIPT)
+    params_file = render_params(**vars(args))
+    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
 

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -92,6 +92,9 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         else:
             args.accessions_file = os.path.abspath(args.accessions_file)
 
+    if args.workflow_def is None:
+        args.workflow_def = os.path.abspath(NXF_SCRIPT)
+
     # Can't validate in the argparse library because --family can be used in modes other family
     # and in that case it is optional; when mode is family then it is required so we validate here
     if args.import_mode == "family" and not args.families:
@@ -114,17 +117,11 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards, accession_shards, blast_matches, job_id,
-                  efi_config, fasta_db, efi_db, multiplex, blast_evalue,
-                  import_mode, sequence_version,
-                  families=None,
-                  sequence_filter=None,
-                  fasta_file=None,
-                  accessions_file=None,
-                  blast_query_file=None,
-                  import_blast_fasta_db=None,
-                  nextflow_config=None,
-                  templates_dir=None, template=None):
+def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
+                  accession_shards, blast_matches, job_id, efi_config, fasta_db, efi_db, multiplex,
+                  blast_evalue, import_mode, sequence_version,
+                  families=None, sequence_filter=None, fasta_file=None, accessions_file=None,
+                  blast_query_file=None, import_blast_fasta_db=None, **kwargs: dict):
     params = {
         "final_output_dir": output_dir,
         "duckdb_memory_limit": duckdb_memory_limit,
@@ -170,5 +167,5 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
     params_file = render_params(**vars(args))
-    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
+    shared_args.save_run_script(args, workflow_def=args.workflow_def, params_file=params_file)
 

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -125,7 +125,6 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
                   import_blast_fasta_db=None,
                   nextflow_config=None,
                   templates_dir=None, template=None, template_env=None):
-                  ):
     params = {
         "final_output_dir": output_dir,
         "duckdb_memory_limit": duckdb_memory_limit,

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -124,7 +124,7 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
                   blast_query_file=None,
                   import_blast_fasta_db=None,
                   nextflow_config=None,
-                  templates_dir=None, template=None, template_env=None):
+                  templates_dir=None, template=None):
     params = {
         "final_output_dir": output_dir,
         "duckdb_memory_limit": duckdb_memory_limit,

--- a/bin/create_generatessn_nextflow_params.py
+++ b/bin/create_generatessn_nextflow_params.py
@@ -107,8 +107,7 @@ def create_parser():
 def render_params(blast_parquet, fasta_file, seq_meta_file, output_dir, filter_parameter,
         filter_min_val, min_length, max_length, ssn_name, ssn_title, maxfull, uniref_version,
         efi_config, db_version, job_id, efi_db, mode,
-        est_output_dir=None, nextflow_config=None, templates_dir=None, template=None,
-        template_env=None):
+        est_output_dir=None, nextflow_config=None, templates_dir=None, template=None):
     params = {
         "blast_parquet": blast_parquet,
         "fasta_file": fasta_file,

--- a/bin/create_generatessn_nextflow_params.py
+++ b/bin/create_generatessn_nextflow_params.py
@@ -90,6 +90,9 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
     else:
         args = validated_args
 
+    if args.workflow_def is None:
+        args.workflow_def = os.path.abspath(NXF_SCRIPT)
+
     if fail:
         print("Failed to render params template")
         exit(1)
@@ -106,8 +109,7 @@ def create_parser():
 
 def render_params(blast_parquet, fasta_file, seq_meta_file, output_dir, filter_parameter,
         filter_min_val, min_length, max_length, ssn_name, ssn_title, maxfull, uniref_version,
-        efi_config, db_version, job_id, efi_db, mode,
-        est_output_dir=None, nextflow_config=None, templates_dir=None, template=None):
+        efi_config, db_version, job_id, efi_db, mode, **kwargs: dict):
     params = {
         "blast_parquet": blast_parquet,
         "fasta_file": fasta_file,
@@ -135,5 +137,5 @@ def render_params(blast_parquet, fasta_file, seq_meta_file, output_dir, filter_p
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
     params_file = render_params(**vars(args))
-    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
+    shared_args.save_run_script(args, workflow_def=args.workflow_def, params_file=params_file)
 

--- a/bin/create_generatessn_nextflow_params.py
+++ b/bin/create_generatessn_nextflow_params.py
@@ -104,7 +104,11 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(blast_parquet, fasta_file, seq_meta_file, output_dir, filter_parameter, filter_min_val, min_length, max_length, ssn_name, ssn_title, maxfull, uniref_version, efi_config, db_version, job_id, efi_db, mode, est_output_dir=None, nextflow_config=None):
+def render_params(blast_parquet, fasta_file, seq_meta_file, output_dir, filter_parameter,
+        filter_min_val, min_length, max_length, ssn_name, ssn_title, maxfull, uniref_version,
+        efi_config, db_version, job_id, efi_db, mode,
+        est_output_dir=None, nextflow_config=None, templates_dir=None, template=None,
+        template_env=None):
     params = {
         "blast_parquet": blast_parquet,
         "fasta_file": fasta_file,
@@ -131,6 +135,6 @@ def render_params(blast_parquet, fasta_file, seq_meta_file, output_dir, filter_p
 
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
-    render_params(**vars(args))
-    shared_args.save_run_script(args, NXF_SCRIPT)
+    params_file = render_params(**vars(args))
+    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
 

--- a/bin/create_gnd_nextflow_params.py
+++ b/bin/create_gnd_nextflow_params.py
@@ -38,6 +38,9 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"Invalid value for --nb-size ({args.nb_size}).")
         fail = True
 
+    if args.workflow_def is None:
+        args.workflow_def = os.path.abspath(NXF_SCRIPT)
+
     if fail:
         print("Failed to render params template")
         exit(1)
@@ -50,8 +53,7 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, job_id,
-        nextflow_config=None, templates_dir=None, template=None):
+def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, **kwargs: dict):
     params = {
         "final_output_dir": output_dir,
         "cluster_id_map": cluster_id_map,
@@ -68,5 +70,5 @@ def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, job_i
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
     params_file = render_params(**vars(args))
-    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
+    shared_args.save_run_script(args, workflow_def=args.workflow_def, params_file=params_file)
 

--- a/bin/create_gnd_nextflow_params.py
+++ b/bin/create_gnd_nextflow_params.py
@@ -51,7 +51,7 @@ def create_parser():
     return parser
 
 def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, job_id,
-        nextflow_config=None, templates_dir=None, template=None, template_env=None):
+        nextflow_config=None, templates_dir=None, template=None):
     params = {
         "final_output_dir": output_dir,
         "cluster_id_map": cluster_id_map,

--- a/bin/create_gnd_nextflow_params.py
+++ b/bin/create_gnd_nextflow_params.py
@@ -50,7 +50,8 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, job_id, nextflow_config=None):
+def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, job_id,
+        nextflow_config=None, templates_dir=None, template=None, template_env=None):
     params = {
         "final_output_dir": output_dir,
         "cluster_id_map": cluster_id_map,
@@ -66,6 +67,6 @@ def render_params(cluster_id_map, efi_config, efi_db, nb_size, output_dir, job_i
 
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
-    render_params(**vars(args))
-    shared_args.save_run_script(args, NXF_SCRIPT)
+    params_file = render_params(**vars(args))
+    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
 

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -62,7 +62,7 @@ def create_parser():
     return parser
 
 def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threshold, output_dir, job_id,
-        nextflow_config=None, templates_dir=None, template=None, template_env=None):
+        nextflow_config=None, templates_dir=None, template=None):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -48,6 +48,9 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"Invalid value for --cooc-threshold ({args.cooc_threshold}).")
         fail = True
 
+    if args.workflow_def is None:
+        args.workflow_def = os.path.abspath(NXF_SCRIPT)
+
     if fail:
         print("Failed to render params template")
         exit(1)
@@ -61,8 +64,8 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threshold, output_dir, job_id,
-        nextflow_config=None, templates_dir=None, template=None):
+def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threshold, output_dir,
+        **kwargs: dict):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,
@@ -81,5 +84,6 @@ def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_thresho
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
     params_file = render_params(**vars(args))
-    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
+    shared_args.save_run_script(args, workflow_def=args.workflow_def, params_file=params_file)
+
 

--- a/bin/create_gnt_nextflow_params.py
+++ b/bin/create_gnt_nextflow_params.py
@@ -61,7 +61,8 @@ def create_parser():
     add_args(parser)
     return parser
 
-def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threshold, output_dir, job_id, nextflow_config=None):
+def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_threshold, output_dir, job_id,
+        nextflow_config=None, templates_dir=None, template=None, template_env=None):
     params = {
         "final_output_dir": output_dir,
         "ssn_input": ssn_input,
@@ -79,6 +80,6 @@ def render_params(ssn_input, efi_config, efi_db, fasta_db, nb_size, cooc_thresho
 
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
-    render_params(**vars(args))
-    shared_args.save_run_script(args, NXF_SCRIPT)
+    params_file = render_params(**vars(args))
+    shared_args.save_run_script(args, workflow_def=NXF_SCRIPT, params_file=params_file)
 

--- a/bin/create_nextflow_job.py
+++ b/bin/create_nextflow_job.py
@@ -85,19 +85,14 @@ if __name__ == "__main__":
     # create params.yml file in the output directory
     if pipeline == "colorssn":
         params_file = create_colorssn_nextflow_params.render_params(**vars(args))
-        workflow_def = create_colorssn_nextflow_params.NXF_SCRIPT
     elif pipeline == "est":
         params_file = create_est_nextflow_params.render_params(**vars(args))
-        workflow_def = create_est_nextflow_params.NXF_SCRIPT
     elif pipeline == "generatessn":
         params_file = create_generatessn_nextflow_params.render_params(**vars(args))
-        workflow_def = create_generatessn_nextflow_params.NXF_SCRIPT
     elif pipeline == "gnt":
         params_file = create_gnt_nextflow_params.render_params(**vars(args))
-        workflow_def = create_gnt_nextflow_params.NXF_SCRIPT
     elif pipeline == "gnd":
         params_file = create_gnd_nextflow_params.render_params(**vars(args))
-        workflow_def = create_gnd_nextflow_params.NXF_SCRIPT
 
-    shared_args.save_run_script(args, workflow_def=workflow_def, params_file=params_file)
+    shared_args.save_run_script(args, workflow_def=args.workflow_def, params_file=params_file)
 

--- a/bin/create_nextflow_job.py
+++ b/bin/create_nextflow_job.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+
 import argparse
 import copy
-from jinja2 import Environment, FileSystemLoader, select_autoescape
 import os
 
 import create_est_nextflow_params
@@ -9,24 +9,13 @@ import create_generatessn_nextflow_params
 import create_colorssn_nextflow_params
 import create_gnt_nextflow_params
 import create_gnd_nextflow_params
+import shared_args
 
 def check_args(args: argparse.Namespace) -> argparse.Namespace:
     """
-    Verify that paths exist and destinations directories exist/are empty. Make
-    paths absolute. Will call ``exit(1)`` if files do not exist.
+    Verify that the pipeline is valid and that the pipeline parameters are valid.  Will call
+    ``exit(1)`` if the pipeline is invalid or if parameters are invalid
     """
-    fail = False
-
-    if not os.path.exists(args.workflow_def):
-        print(f"Workflow definition '{args.workflow_def}' does not exist")
-        fail = True
-
-    if fail:
-        print("Failed to generate run script")
-        exit(1)
-    else:
-        args.workflow_def = os.path.abspath(args.workflow_def)
-
     if args.pipeline == "colorssn":
         args = create_colorssn_nextflow_params.check_args(args)
     elif args.pipeline == "est":
@@ -48,81 +37,46 @@ def create_parser() -> argparse.ArgumentParser:
     Define the parent parser for job script creation and adds subcommands for
     different pipelines
     """
-    parser = argparse.ArgumentParser(description="Render templates for nextflow job run")
-    # batch args
-    default_template_path = os.path.join(os.path.dirname(__file__), "templates")
-    parser.add_argument("--templates-dir", type=str, default=default_template_path, help="Directory where job script templates are stored")
-    subparsers = parser.add_subparsers(dest="pipeline", required=True,)
+    parser = argparse.ArgumentParser(description="Create a job script from a template that runs Nextflow")
+    subparsers = parser.add_subparsers(dest="pipeline", required=True)
 
     # add pipelines as subcommands
     colorssn_parser = subparsers.add_parser("colorssn", help="Create a Color SSN pipeline job script")
-    nxf_script_path = os.path.join(os.path.dirname(__file__), "../", create_colorssn_nextflow_params.NXF_SCRIPT)
-    colorssn_parser.add_argument("--workflow-def", default=nxf_script_path, help="Location of the Color SSN nextflow workflow file")
     create_colorssn_nextflow_params.add_args(colorssn_parser)
 
     est_parser = subparsers.add_parser("est", help="Create an EST pipeline job script")
-    nxf_script_path = os.path.join(os.path.dirname(__file__), "../", create_est_nextflow_params.NXF_SCRIPT)
-    est_parser.add_argument("--workflow-def", type=str, default=nxf_script_path, help="Location of the EST nextflow workflow file")
     create_est_nextflow_params.add_args(est_parser)
 
     generatessn_parser = subparsers.add_parser("generatessn", help="Create a generate-SSN pipeline job script")
-    nxf_script_path = os.path.join(os.path.dirname(__file__), "../", create_generatessn_nextflow_params.NXF_SCRIPT)
-    generatessn_parser.add_argument("--workflow-def", type=str, default=nxf_script_path, help="Location of the SSN nextflow workflow file")
     create_generatessn_nextflow_params.add_args(generatessn_parser)
 
     gnd_parser = subparsers.add_parser("gnd", help="Create a GND pipeline job script")
-    nxf_script_path = os.path.join(os.path.dirname(__file__), "../", create_gnd_nextflow_params.NXF_SCRIPT)
-    gnd_parser.add_argument("--workflow-def", default=nxf_script_path, help="Location of the GND workflow file")
     create_gnd_nextflow_params.add_args(gnd_parser)
 
     gnt_parser = subparsers.add_parser("gnt", help="Create a GNT pipeline job script")
-    nxf_script_path = os.path.join(os.path.dirname(__file__), "../", create_gnt_nextflow_params.NXF_SCRIPT)
-    gnt_parser.add_argument("--workflow-def", default=nxf_script_path, help="Location of the GNT workflow file")
     create_gnt_nextflow_params.add_args(gnt_parser)
 
     return parser
 
-
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
 
-    # remove args not relevant to params rendering
-    args_dict = copy.deepcopy(vars(args))
-    del args_dict["pipeline"]
-    del args_dict["workflow_def"]
-    del args_dict["templates_dir"]
+    # create params.yml file in the output directory
     if args.pipeline == "colorssn":
-        params_output = create_colorssn_nextflow_params.render_params(**args_dict)
+        params_file = create_colorssn_nextflow_params.render_params(**args)
+        workflow_def = create_colorssn_nextflow_params.NXF_SCRIPT
     elif args.pipeline == "est":
-        params_output = create_est_nextflow_params.render_params(**args_dict)
+        params_file = create_est_nextflow_params.render_params(**args)
+        workflow_def = create_est_nextflow_params.NXF_SCRIPT
     elif args.pipeline == "generatessn":
-        params_output = create_generatessn_nextflow_params.render_params(**args_dict)
+        params_file = create_generatessn_nextflow_params.render_params(**args)
+        workflow_def = create_generatessn_nextflow_params.NXF_SCRIPT
     elif args.pipeline == "gnt":
-        params_output = create_gnt_nextflow_params.render_params(**args_dict)
+        params_file = create_gnt_nextflow_params.render_params(**args)
+        workflow_def = create_gnt_nextflow_params.NXF_SCRIPT
     elif args.pipeline == "gnd":
-        params_output = create_gnd_nextflow_params.render_params(**args_dict)
-    else:
-        print(f"Job type '{args.pipeline}' not known")
-        exit(1)
+        params_file = create_gnd_nextflow_params.render_params(**args)
+        workflow_def = create_gnd_nextflow_params.NXF_SCRIPT
 
-    efi_home = os.path.join(os.path.dirname(__file__), "..")
-
-    env = Environment(loader=FileSystemLoader(args.templates_dir), autoescape=select_autoescape())
-    sh_template = env.get_template("run_nextflow_slurm.sh.jinja")
-
-    submission_script = sh_template.render(workflow_definition=args.workflow_def, 
-                                           params_file=params_output,
-                                           report_file="report.html",
-                                           timeline_file="timeline.html",
-                                           output_dir=args.output_dir,
-                                           jobtype=args.pipeline,
-                                           job_id=args.job_id,
-                                           config_path=args.nextflow_config,
-                                           efi_home=efi_home,
-                                           load_modules=True)
-    submission_script_output = os.path.join(args.output_dir, "run_nextflow.sh")
-    with open(submission_script_output, "w") as f:
-        f.write(submission_script)
-        f.write("\n")
-    print(f"Wrote submission script to {submission_script_output}")
+    shared_args.save_run_script(args, workflow_def=workflow_def, params_file=params_file)
 

--- a/bin/create_nextflow_job.py
+++ b/bin/create_nextflow_job.py
@@ -11,11 +11,23 @@ import create_gnt_nextflow_params
 import create_gnd_nextflow_params
 import shared_args
 
+DEFAULT_NXF_TEMPLATE = "run_nextflow_slurm.sh.jinja"
+
 def check_args(args: argparse.Namespace) -> argparse.Namespace:
     """
     Verify that the pipeline is valid and that the pipeline parameters are valid.  Will call
     ``exit(1)`` if the pipeline is invalid or if parameters are invalid
     """
+
+    # at this point the parser has set args.template to a non-null value if it was set, otherwise
+    # it is None, and we need to indicate to the code that it should be set to the default
+    # template after the other parsers have completed their tasks; this happens because they
+    # set the template to a default as well in check_args()
+    if args.template is None:
+        override_template = True
+    else:
+        override_template = False
+
     if args.pipeline == "colorssn":
         args = create_colorssn_nextflow_params.check_args(args)
     elif args.pipeline == "est":
@@ -29,6 +41,12 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
     else:
         print(f"Job type '{args.pipeline}' not known")
         exit(1)
+
+    # set the default template for Nextflow if the template was not specified by the user, because
+    # at this point the code has set the template in check_args() for when the other types of jobs
+    # are run
+    if override_template:
+        args.template = DEFAULT_NXF_TEMPLATE
 
     return args
 
@@ -61,21 +79,24 @@ def create_parser() -> argparse.ArgumentParser:
 if __name__ == "__main__":
     args = check_args(create_parser().parse_args())
 
+    pipeline = args.pipeline
+    del args.pipeline
+
     # create params.yml file in the output directory
-    if args.pipeline == "colorssn":
-        params_file = create_colorssn_nextflow_params.render_params(**args)
+    if pipeline == "colorssn":
+        params_file = create_colorssn_nextflow_params.render_params(**vars(args))
         workflow_def = create_colorssn_nextflow_params.NXF_SCRIPT
-    elif args.pipeline == "est":
-        params_file = create_est_nextflow_params.render_params(**args)
+    elif pipeline == "est":
+        params_file = create_est_nextflow_params.render_params(**vars(args))
         workflow_def = create_est_nextflow_params.NXF_SCRIPT
-    elif args.pipeline == "generatessn":
-        params_file = create_generatessn_nextflow_params.render_params(**args)
+    elif pipeline == "generatessn":
+        params_file = create_generatessn_nextflow_params.render_params(**vars(args))
         workflow_def = create_generatessn_nextflow_params.NXF_SCRIPT
-    elif args.pipeline == "gnt":
-        params_file = create_gnt_nextflow_params.render_params(**args)
+    elif pipeline == "gnt":
+        params_file = create_gnt_nextflow_params.render_params(**vars(args))
         workflow_def = create_gnt_nextflow_params.NXF_SCRIPT
-    elif args.pipeline == "gnd":
-        params_file = create_gnd_nextflow_params.render_params(**args)
+    elif pipeline == "gnd":
+        params_file = create_gnd_nextflow_params.render_params(**vars(args))
         workflow_def = create_gnd_nextflow_params.NXF_SCRIPT
 
     shared_args.save_run_script(args, workflow_def=workflow_def, params_file=params_file)

--- a/bin/shared_args.py
+++ b/bin/shared_args.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import argparse
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 import os
 
 SCRIPT_NAME = "run_nextflow.sh"
 PARAMS_NAME = "params.yml"
+DEFAULT_TEMPLATE = "run_nextflow_cli.sh.jinja"
 
 def add_args(parser: argparse.ArgumentParser, use_output_dir: bool = True):
     """
@@ -15,7 +17,13 @@ def add_args(parser: argparse.ArgumentParser, use_output_dir: bool = True):
     parser.add_argument("--efi-config", required=True, type=str, help="EFI configuration file path")
     parser.add_argument("--efi-db", required=True, type=str, help="Name of the MySQL database to use (e.g. efi_202406) or name of the SQLite file")
     parser.add_argument("--nextflow-config", required=True, type=str, help="Path to the Nextflow configuration file to use (e.g. conf/est/docker.config)")
-    parser.add_argument("--job-id", default=131, help="ID used when running on the EFI website. Not important otherwise")
+    parser.add_argument("--job-id", default=42, help="Identifier used to in the job name when submitting a Nextflow job to a scheduler")
+
+    # template args, for creating run scripts
+    default_template_path = os.path.join(os.path.dirname(__file__), "templates")
+    parser.add_argument("--templates-dir", type=str, default=default_template_path, help="Directory where job script templates are stored")
+    parser.add_argument("--template", type=str, default=DEFAULT_TEMPLATE, help="Name of template file to use -- must be one of those located in templates dir")
+    parser.add_argument("--template-env", type=str, help="Path to environment file to include into script template")
 
 def check_args(args: argparse.Namespace) -> argparse.Namespace:
     """
@@ -53,7 +61,28 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
             args.efi_db = os.path.abspath(args.efi_db)
         return args
 
-def save_run_script(args: argparse.Namespace, nxf_script_path: str):
+def load_env_file(file_path: str) -> list:
+    """
+    Get all of the lines from the file and return them as a list.  The file is assumed to be a
+    file containing environment variables and other environment settings necessary to run Nextflow.
+    All lines are returned from the file.
+
+    Parameters
+    ----------
+        file_path
+            Path to a file, typically shell script
+
+    Returns
+    -------
+        list of lines
+    """
+    lines = []
+    with open(file_path, "r") as fh:
+        for line in fh:
+            lines.append(line.strip())
+    return lines
+
+def save_run_script(args: argparse.Namespace, workflow_def: str, params_file: str):
     """
     Save the nextflow execution command to a file for easier use by the user.
 
@@ -61,19 +90,34 @@ def save_run_script(args: argparse.Namespace, nxf_script_path: str):
     ----------
         args
             ArgumentParser containing all the arguments used to generate the params file
-        nxf_script_path
-            path to the nextflow script relative to the repo root (e.g. 'pipelines/est/est.nf')
+        workflow_def
+            Path to a Nextflow workflow definition
+        params_file
+            Path to a file containing the parameters passed to a Nextflow workflow
     """
-    script = os.path.join(args.output_dir, SCRIPT_NAME)
-    efi_data_dir = os.path.dirname(args.efi_config)
-    nxf_log_file = os.path.join(args.output_dir, "nextflow.log")
-    nxf_work_dir = os.path.join(args.output_dir, "work")
-    params_file = os.path.join(args.output_dir, PARAMS_NAME)
-    nxf_script_path = os.path.join(os.path.dirname(__file__), "../", nxf_script_path)
 
-    with open(script, "w") as fh:
-        fh.write("#!/bin/bash\n")
-        fh.write(f"export EFI_DATA_DIR=\"{efi_data_dir}\"\n")
-        fh.write(f"nextflow -C {args.nextflow_config} -log {nxf_log_file} run {nxf_script_path} -params-file {params_file} -w {nxf_work_dir}\n")
-        #nextflow -log $OUTPUT_DIR/est_nextflow.log -C $NXF_EST_CONFIG_FILE run pipelines/est/est.nf -params-file $OUTPUT_DIR/params.yml -w $OUTPUT_DIR/est_work
+    env = Environment(loader=FileSystemLoader(args.templates_dir), autoescape=select_autoescape())
+    sh_template = env.get_template(args.template)
+
+    if args.template_env:
+        system_env = load_env_file(args.template_env)
+    else:
+        system_env = []
+
+    pipeline_name = os.path.splitext(os.path.basename(workflow_def))
+
+    run_script = sh_template.render(workflow_definition=workflow_def, 
+                                    params_file=params_file,
+                                    output_dir=args.output_dir,
+                                    config_path=args.nextflow_config,
+                                    system_env=system_env,
+                                    jobtype=pipeline_name,
+                                    job_id=args.job_id,
+                                    report_file="report.html",
+                                    timeline_file="timeline.html")
+    startup_script = os.path.join(args.output_dir, SCRIPT_NAME)
+    with open(startup_script, "w") as f:
+        f.write(run_script)
+        f.write("\n")
+    print(f"Wrote Nextflow script to {startup_script}")
 

--- a/bin/shared_args.py
+++ b/bin/shared_args.py
@@ -18,6 +18,7 @@ def add_args(parser: argparse.ArgumentParser, use_output_dir: bool = True):
     parser.add_argument("--efi-db", required=True, type=str, help="Name of the MySQL database to use (e.g. efi_202406) or name of the SQLite file")
     parser.add_argument("--nextflow-config", required=True, type=str, help="Path to the Nextflow configuration file to use (e.g. conf/est/docker.config)")
     parser.add_argument("--job-id", default=42, help="Identifier used to in the job name when submitting a Nextflow job to a scheduler")
+    parser.add_argument("--workflow-def", help="Path to the Nextflow workflow definition file, relative to repository root (e.g. pipelines/est/est.nf)")
 
     # template args, for creating run scripts
     default_template_path = os.path.join(os.path.dirname(__file__), "templates")
@@ -55,6 +56,9 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
     # set the default template
     if args.template is None:
         args.template = DEFAULT_TEMPLATE
+
+    if args.workflow_def is not None:
+        args.workflow_def = os.path.abspath(args.workflow_def)
 
     if fail:
         return None

--- a/bin/shared_args.py
+++ b/bin/shared_args.py
@@ -22,8 +22,9 @@ def add_args(parser: argparse.ArgumentParser, use_output_dir: bool = True):
     # template args, for creating run scripts
     default_template_path = os.path.join(os.path.dirname(__file__), "templates")
     parser.add_argument("--templates-dir", type=str, default=default_template_path, help="Directory where job script templates are stored")
-    parser.add_argument("--template", type=str, default=DEFAULT_TEMPLATE, help="Name of template file to use -- must be one of those located in templates dir")
-    parser.add_argument("--template-env", type=str, help="Path to environment file to include into script template")
+    # do not add a default value for --template because the create_nextflow_job.py script needs
+    # to know if a template was specified or not
+    parser.add_argument("--template", type=str, help="Name of template file to use -- must be one of those located in --templates-dir or bin/templates")
 
 def check_args(args: argparse.Namespace) -> argparse.Namespace:
     """
@@ -51,6 +52,10 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         print(f"EFI config file '{args.efi_config}' does not exist")
         fail = True
 
+    # set the default template
+    if args.template is None:
+        args.template = DEFAULT_TEMPLATE
+
     if fail:
         return None
     else:
@@ -60,27 +65,6 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         if os.path.exists(args.efi_db):
             args.efi_db = os.path.abspath(args.efi_db)
         return args
-
-def load_env_file(file_path: str) -> list:
-    """
-    Get all of the lines from the file and return them as a list.  The file is assumed to be a
-    file containing environment variables and other environment settings necessary to run Nextflow.
-    All lines are returned from the file.
-
-    Parameters
-    ----------
-        file_path
-            Path to a file, typically shell script
-
-    Returns
-    -------
-        list of lines
-    """
-    lines = []
-    with open(file_path, "r") as fh:
-        for line in fh:
-            lines.append(line.strip())
-    return lines
 
 def save_run_script(args: argparse.Namespace, workflow_def: str, params_file: str):
     """
@@ -99,18 +83,12 @@ def save_run_script(args: argparse.Namespace, workflow_def: str, params_file: st
     env = Environment(loader=FileSystemLoader(args.templates_dir), autoescape=select_autoescape())
     sh_template = env.get_template(args.template)
 
-    if args.template_env:
-        system_env = load_env_file(args.template_env)
-    else:
-        system_env = []
-
     pipeline_name = os.path.splitext(os.path.basename(workflow_def))
 
     run_script = sh_template.render(workflow_definition=workflow_def, 
                                     params_file=params_file,
                                     output_dir=args.output_dir,
                                     config_path=args.nextflow_config,
-                                    system_env=system_env,
                                     jobtype=pipeline_name,
                                     job_id=args.job_id,
                                     report_file="report.html",

--- a/bin/templates/run_nextflow_cli.sh.jinja
+++ b/bin/templates/run_nextflow_cli.sh.jinja
@@ -1,8 +1,9 @@
 #!/bin/bash
+#
+# This is the default command-line interface template that is used for testing or by a user when
+# running on a system through Docker or a manual installation.  Include here any environment setup
+# that is required (e.g. source, venv) to run.
 
-{% for env_line in system_env %}
-{{ env_line }}
-{% endfor %}
-
+# Normally nothing should be changed here
 nextflow -C {{ config_path }} -log {{ output_dir }}/nextflow.log run {{ workflow_definition }} -params-file {{ params_file }} -with-report {{ output_dir }}/{{ report_file }} -with-timeline {{ output_dir }}/{{ timeline_file }} -w {{ output_dir }}/work
 

--- a/bin/templates/run_nextflow_cli.sh.jinja
+++ b/bin/templates/run_nextflow_cli.sh.jinja
@@ -1,10 +1,4 @@
 #!/bin/bash
-#SBATCH --partition=efi
-#SBATCH -c 2
-#SBATCH --mem=32GB
-#SBATCH --job-name="{{ jobtype }}-{{ job_id }}"
-#SBATCH -o {{ output_dir }}/nextflow.stdout
-#SBATCH -e {{ output_dir }}/nextflow.stderr
 
 {% for env_line in system_env %}
 {{ env_line }}

--- a/bin/templates/run_nextflow_slurm.sh.jinja
+++ b/bin/templates/run_nextflow_slurm.sh.jinja
@@ -1,14 +1,26 @@
 #!/bin/bash
-#SBATCH --partition=efi
-#SBATCH -c 2
-#SBATCH --mem=32GB
-#SBATCH --job-name="{{ jobtype }}-{{ job_id }}"
+#
+# Instructions:
+#     1. Change -p PARTITION to the Slurm partition that the jobs will run on
+#     2. Change -c NCPU to the number of CPUs allowed per task; this should match the number of
+#        BLAST instances that will be used in the all-by-all computation
+#     3. Change --mem=XXGB to the amount of memory that is required per node, where XX is the
+#        RAM size in GB
+#     4. No changes should be made to the -J, -o, and -e arguments
+#     5. Add any other #SBATCH lines required, e.g. --mail-user, after
+#
+#SBATCH -p PARTITION
+#SBATCH -c NCPU
+#SBATCH --mem=XXGB
+#SBATCH -J "{{ jobtype }}-{{ job_id }}" # useful for running on a cluster, to identify the job
 #SBATCH -o {{ output_dir }}/nextflow.stdout
 #SBATCH -e {{ output_dir }}/nextflow.stderr
 
-{% for env_line in system_env %}
-{{ env_line }}
-{% endfor %}
 
+# Include any additional environment variables, sources, or module loads necessary to run the
+# scripts on this system, e.g. a Python venv or module load BLAST, here
+
+
+# Normally nothing should be changed here
 nextflow -C {{ config_path }} -log {{ output_dir }}/nextflow.log run {{ workflow_definition }} -params-file {{ params_file }} -with-report {{ output_dir }}/{{ report_file }} -with-timeline {{ output_dir }}/{{ timeline_file }} -w {{ output_dir }}/work
 

--- a/tests/modules/05_colorssn_uniprot.sh
+++ b/tests/modules/05_colorssn_uniprot.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [[ ! -e "$EFI_TEST_SSN_UNIPROT" ]]; then
+    echo "Test skipped; missing $EFI_TEST_SSN_UNIPROT"
+    exit 0
+fi
+
 TEST_RESULTS_DIR=$1
 CONFIG_FILE=$2
 NXF_COLORSSN_CONFIG_FILE="conf/colorssn/$CONFIG_FILE"
@@ -10,14 +15,6 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-ssn_file=$EFI_TEST_SSN_UNIPROT
-if [[ ! -e "$ssn_file" ]]; then
-    ssn_file="$TEST_RESULTS_DIR/test_results_accession/ssn/full_ssn.xgmml"
-fi
-if [[ ! -e "$ssn_file" ]]; then
-    exit 1
-fi
-
-./bin/create_colorssn_nextflow_params.py --output-dir $OUTPUT_DIR --ssn-input $ssn_file --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --nextflow-config $NXF_COLORSSN_CONFIG_FILE
+./bin/create_colorssn_nextflow_params.py --output-dir $OUTPUT_DIR --ssn-input $EFI_TEST_SSN_UNIPROT --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --nextflow-config $NXF_COLORSSN_CONFIG_FILE
 bash $OUTPUT_DIR/run_nextflow.sh
 

--- a/tests/modules/09_gnt.sh
+++ b/tests/modules/09_gnt.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [[ ! -e "$EFI_TEST_SSN_UNIPROT" ]]; then
+    echo "Test skipped; missing $EFI_TEST_SSN_UNIPROT"
+    exit 0
+fi
+
 TEST_RESULTS_DIR=$1
 CONFIG_FILE=$2
 NXF_GNT_CONFIG_FILE="conf/gnt/$CONFIG_FILE"
@@ -10,12 +15,6 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-ssn_file=$EFI_TEST_SSN_UNIPROT
-if [[ ! -e "$ssn_file" ]]; then
-    echo "Missing ssn file"
-    exit 1
-fi
-
-./bin/create_gnt_nextflow_params.py --output-dir $OUTPUT_DIR --ssn-input $ssn_file --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --nextflow-config $NXF_GNT_CONFIG_FILE
+./bin/create_gnt_nextflow_params.py --output-dir $OUTPUT_DIR --ssn-input $EFI_TEST_SSN_UNIPROT --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --nextflow-config $NXF_GNT_CONFIG_FILE
 bash $OUTPUT_DIR/run_nextflow.sh
 


### PR DESCRIPTION
Updates all job script generation scripts in `bin/create*.py` to accept Jinja templates for generating shell scripts to run Nextflow.  The Jinja templates are designed to be copied and modified to include implementation-specific environment variables and configurations in the output `run_nextflow.sh` script.  Also requires presence of UniRef and RepNode SSNs for Color SSN and GNT tests.