### PR TITLE
223 Add domain_region parameter to EST nextflow pipeline

### DIFF
--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -26,7 +26,8 @@ def add_args(parser: argparse.ArgumentParser):
     common_parser.add_argument("--sequence-version", type=str, default="uniprot", choices=["uniprot", "uniref90", "uniref50"])
     common_parser.add_argument("--filter", action="append", type=str, help="Filter sequences, use multiple times to indicate filter types")
     common_parser.add_argument("--families", type=str, help="Comma-separated list of families to add")
-    common_parser.add_argument("--domain", choices=["central", "n-terminal", "c-terminal"], type=str, help="Trim sequences to domain boundaries")
+    common_parser.add_argument("--domain", default=False, action="store_true", help="Should sequences be trimmed to domain boundaries?")
+    common_parser.add_argument("--domain-region", choices=["central", "n-terminal", "c-terminal"], type=str, help="Trim sequences to domain boundaries")
     shared_args.add_args(common_parser)
 
     # add a subparser for each import mode
@@ -123,10 +124,10 @@ def create_parser() -> argparse.ArgumentParser:
 
 def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
                   accession_shards, blast_num_matches, job_id, efi_config, fasta_db, efi_db, multiplex,
-                  blast_evalue, import_mode, sequence_version,
+                  blast_evalue, import_mode, sequence_version, domain,
                   families=None, sequence_filter=None, fasta_file=None, accessions_file=None,
                   blast_query_file=None, import_blast_fasta_db=None, import_blast_num_matches=None,
-                  import_blast_evalue=None, domain=None, domain_family=None, **kwargs: dict):
+                  import_blast_evalue=None, domain_region=None, domain_family=None, **kwargs: dict):
     params = {
         "final_output_dir": output_dir,
         "duckdb_memory_limit": duckdb_memory_limit,
@@ -143,7 +144,8 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
         "blast_num_matches": blast_num_matches,
         "blast_evalue": blast_evalue,
         "sequence_version": sequence_version,
-        "domain": None,
+        "domain": domain,
+        "domain_region": None,
         "import_blast_fasta_db": None,
         "accessions_file": None,
         "import_blast_num_matches": None,
@@ -174,9 +176,9 @@ def render_params(output_dir, duckdb_memory_limit, duckdb_threads, fasta_shards,
             "families": families
         }
 
-    if domain is not None:
+    if domain and domain_region is not None:
         params |= {
-            "domain": domain
+            "domain_region": domain_region
         }
         if import_mode == "accessions" and domain_family is not None:
             params |= {

--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -27,7 +27,7 @@ def add_args(parser: argparse.ArgumentParser):
     common_parser.add_argument("--filter", action="append", type=str, help="Filter sequences, use multiple times to indicate filter types")
     common_parser.add_argument("--families", type=str, help="Comma-separated list of families to add")
     common_parser.add_argument("--domain", default=False, action="store_true", help="Should sequences be trimmed to domain boundaries?")
-    common_parser.add_argument("--domain-region", choices=["central", "n-terminal", "c-terminal"], type=str, help="Trim sequences to domain boundaries")
+    common_parser.add_argument("--domain-region", choices=["domain", "n-terminal", "c-terminal"], type=str, help="Trim sequences to domain boundaries")
     shared_args.add_args(common_parser)
 
     # add a subparser for each import mode

--- a/docs/source/pipelines/est/import/get_sequence_ids.rst
+++ b/docs/source/pipelines/est/import/get_sequence_ids.rst
@@ -32,7 +32,7 @@ Usage
 	    --unmatched-ids            file containing IDs in FASTA or accession ID files that were not matched in the EFI database
 	    --blast-query              path to file containing sequence for initial BLAST; required for --mode blast
 	    --blast-output             output file to put BLAST results into; required for --mode blast
-	    --domain                   retrieve the family domain on each sequence; 'central' retrieves the domain of the input family, 'n-terminal' or 'c-terminal' retrieve the portion of the sequence that is n-terminal or c-terminal to the family domain
+	    --domain                   retrieve the family domain on each sequence; 'domain' retrieves the domain of the input family, 'n-terminal' or 'c-terminal' retrieve the portion of the sequence that is n-terminal or c-terminal to the family domain
 	    --domain-family            the family to use when retrieving domains for Accession jobs only
 	
 

--- a/lib/EFI/Import/Config/Source.pm
+++ b/lib/EFI/Import/Config/Source.pm
@@ -42,7 +42,7 @@ sub addImportOptions {
     $self->addOption("unmatched-ids=s", 0, "file containing IDs in FASTA or accession ID files that were not matched in the EFI database", OPT_FILE);
     $self->addOption("blast-query=s", 0, "path to file containing sequence for initial BLAST; required for --mode blast", OPT_FILE);
     $self->addOption("blast-output=s", 0, "output file to put BLAST results into; required for --mode blast", OPT_FILE);
-    $self->addOption("domain=s", 0, "retrieve the family domain on each sequence; 'central' retrieves the domain of the input family, 'n-terminal' or 'c-terminal' retrieve the portion of the sequence that is n-terminal or c-terminal to the family domain");
+    $self->addOption("domain=s", 0, "retrieve the family domain on each sequence; 'domain' retrieves the domain of the input family, 'n-terminal' or 'c-terminal' retrieve the portion of the sequence that is n-terminal or c-terminal to the family domain");
     $self->addOption("domain-family=s", 0, "the family to use when retrieving domains for Accession jobs only");
 }
 

--- a/lib/EFI/Import/Domains.pm
+++ b/lib/EFI/Import/Domains.pm
@@ -13,7 +13,7 @@ use EFI::Database::Util;
 
 use constant DOMAIN_NTERMINAL => "n-terminal";
 use constant DOMAIN_CTERMINAL => "c-terminal";
-use constant DOMAIN_CENTRAL => "central";
+use constant DOMAIN_CENTRAL => "domain";
 
 use Exporter qw(import);
 our %EXPORT_TAGS = (
@@ -134,7 +134,7 @@ sub computeDomains {
 # Converts the user-specified string into an internal flag
 #
 # Parameters:
-#    $region - "n-terminal", "c-terminal", "central"
+#    $region - "n-terminal", "c-terminal", "domain"
 #
 # Returns:
 #    DOMAIN_NTERMINAL, DOMAIN_CTERMINAL, DOMAIN_CENTRAL

--- a/pipelines/est/subworkflows/import.nf
+++ b/pipelines/est/subworkflows/import.nf
@@ -20,7 +20,7 @@ process get_source_ids {
     }
 
     if (params.domain) {
-        family_args = family_args + " --domain " + params.domain
+        family_args = family_args + " --domain " + params.domain_region
         if (params.domain_family) {
             family_args = family_args + " --domain-family " + params.domain_family
         }

--- a/tests/modules/01b_est_family_filter_taxonomy_predef_path.sh
+++ b/tests/modules/01b_est_family_filter_taxonomy_predef_path.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --filter predef-file=$PWD/assets/predefined_taxonomy_filters.yml --filter predef-filter=bacteria
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --filter predef-file=$PWD/pipelines/shared/assets/predefined_taxonomy_filters.yml --filter predef-filter=bacteria
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/01k_est_family_domain.sh
+++ b/tests/modules/01k_est_family_domain.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family="IPR050967"
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain --domain-region central
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain --domain-region domain
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/01k_est_family_domain.sh
+++ b/tests/modules/01k_est_family_domain.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family="IPR050967"
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain central
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain --domain-region central
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/04m_est_accession_domain.sh
+++ b/tests/modules/04m_est_accession_domain.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region central --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region domain --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/04m_est_accession_domain.sh
+++ b/tests/modules/04m_est_accession_domain.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain central --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain true --domain-region central --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/04m_est_accession_domain.sh
+++ b/tests/modules/04m_est_accession_domain.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain true --domain-region central --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region central --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/01l_est_family_domain_nterminal.sh
+++ b/tests/modules/extended/01l_est_family_domain_nterminal.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family="IPR050967"
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain n-terminal
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain --domain-region n-terminal
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/01m_est_family_domain_cterminal.sh
+++ b/tests/modules/extended/01m_est_family_domain_cterminal.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family="IPR050967"
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain c-terminal
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain --domain-region c-terminal
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04n_est_accession_domain_nterminal.sh
+++ b/tests/modules/extended/04n_est_accession_domain_nterminal.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain n-terminal --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region n-terminal --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04o_est_accession_domain_cterminal.sh
+++ b/tests/modules/extended/04o_est_accession_domain_cterminal.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain c-terminal --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region c-terminal --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME


### PR DESCRIPTION
Add the domain_region nextflow parameter to limit the influence of the params.domain parameter to just be a boolean. This mirrors how the efi-web domain-related columns in the Job table is handled. 

closes #223 