### PR TITLE
225 - Single parameter for EST input files

### DIFF
--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -28,14 +28,14 @@ def add_args(parser: argparse.ArgumentParser):
     common_parser.add_argument("--families", type=str, help="Comma-separated list of families to add")
     common_parser.add_argument("--domain", action="store_true", help="Should sequences be trimmed to domain boundaries?")
     common_parser.add_argument("--domain-region", choices=["domain", "n-terminal", "c-terminal"], type=str, help="Trim sequences to domain boundaries")
+    common_parser.add_argument("--input-file", type=str, help="Input file containing the information needed to gather sequences. Used in ACCESSIONS, BLAST, and FASTA import modes.")
     shared_args.add_args(common_parser)
 
     # Add a subparser for each import mode
     subparsers = parser.add_subparsers(dest="import_mode", required=True)
-    
+
     # Option A: Sequence BLAST
     blast_parser = subparsers.add_parser("blast", help="Import sequences using the single sequence BLAST option", parents=[common_parser]).add_argument_group("Sequence BLAST Options")
-    blast_parser.add_argument("--blast-query-file", required=True, type=str, help="The file containing a single sequence to use for the initial BLAST to obtain sequences")
     blast_parser.add_argument("--import-blast-fasta-db", type=str, help="FASTA file or BLAST database to use for the initial import to find sequences; must be set if the --sequence-version is uniref50 or uniref90; defaults to the same as --fasta-db.")
     blast_parser.add_argument("--import-blast-num-matches", type=int, help="Maximum number of matches returned by BLAST when retrieving sequences")
     blast_parser.add_argument("--import-blast-evalue", help="Cutoff e-value to use in the BLAST sequence alignment when retrieving sequences")
@@ -46,11 +46,9 @@ def add_args(parser: argparse.ArgumentParser):
 
     # Option C: FASTA
     fasta_parser = subparsers.add_parser("fasta", help="Import sequences using the FASTA option", parents=[common_parser]).add_argument_group("FASTA Options")
-    fasta_parser.add_argument("--fasta-file", required=True, type=str, help="The FASTA file to read sequences from")
 
     # Option D: Accession IDs
     accession_parser = subparsers.add_parser("accessions", help="Import sequences using the Accession option", parents=[common_parser]).add_argument_group("Accession ID Options")
-    accession_parser.add_argument("--accessions-file", required=True, type=str, help="The list of Accession IDs to pull sequences for, one per line")
     accession_parser.add_argument("--domain-family", type=str, help="Family to use when trimming sequences to domain boundaries")
 
 def check_args(args: argparse.Namespace) -> argparse.Namespace:
@@ -73,29 +71,19 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
 
     # Import mode-specific tests
     if args.import_mode == "blast":
-        if not os.path.exists(args.blast_query_file):
-            print(f"BLAST query file '{args.blast_query_file}' does not exist")
-            fail = True
-        else:
-            args.blast_query_file = os.path.abspath(args.blast_query_file)
         if args.import_blast_fasta_db is not None:
             # Use the UniRef database for the BLAST
             args.import_blast_fasta_db = os.path.abspath(args.import_blast_fasta_db)
         else:
             # Use the main database for the BLAST
             args.import_blast_fasta_db = os.path.abspath(args.fasta_db)
-    elif args.import_mode == "fasta":
-        if not os.path.exists(args.fasta_file):
-            print(f"FASTA import mode: FASTA file '{args.fasta_file}' does not exist")
-            fail = True
-        else:
-            args.fasta_file = os.path.abspath(args.fasta_file)
-    elif args.import_mode == "accessions":
-        if not os.path.exists(args.accessions_file):
-            print(f"Accession ID list '{args.accessions_file}' does not exist")
-            fail = True
-        else:
-            args.accessions_file = os.path.abspath(args.accessions_file)
+
+    # Handle a sequence-specifying input file for BLAST, ACCESSION, and FASTA input modes
+    if args.input_file and not os.path.exists(args.input_file):
+        print(f"Input file for sequence importing '{args.input_file}' does not exist")
+        fail = True
+    elif args.input_file:
+        args.input_file = os.path.abspath(args.input_file)
 
     if args.workflow_def is None:
         args.workflow_def = os.path.abspath(NXF_SCRIPT)
@@ -126,12 +114,12 @@ def render_params(output_dir, import_mode, sequence_version, job_id, efi_config,
                   duckdb_memory_limit=None, duckdb_threads=None, fasta_shards=None,
                   accession_shards=None, blast_num_matches=None, multiplex=None,
                   blast_evalue=None, domain=None, families=None, sequence_filter=None,
-                  fasta_file=None, accessions_file=None, blast_query_file=None, 
-                  import_blast_fasta_db=None, import_blast_num_matches=None,
+                  input_file=None, import_blast_fasta_db=None, import_blast_num_matches=None,
                   import_blast_evalue=None, domain_region=None, domain_family=None,
                   **kwargs: dict):
     params = {
         "final_output_dir": output_dir,
+        "input_file": input_file,
         "duckdb_memory_limit": duckdb_memory_limit,
         "duckdb_threads": duckdb_threads,
         "num_fasta_shards": fasta_shards,
@@ -150,18 +138,9 @@ def render_params(output_dir, import_mode, sequence_version, job_id, efi_config,
     }
     if import_mode == "blast":
         params |= {
-            "blast_query_file": blast_query_file,
             "import_blast_fasta_db": import_blast_fasta_db,
             "import_blast_num_matches": import_blast_num_matches,
             "import_blast_evalue": import_blast_evalue
-        }
-    elif import_mode == "fasta":
-        params |= {
-            "uploaded_fasta_file": fasta_file
-        }
-    elif import_mode == "accessions":
-        params |= {
-            "accessions_file": accessions_file
         }
 
     if families is not None:

--- a/bin/create_generatessn_nextflow_params.py
+++ b/bin/create_generatessn_nextflow_params.py
@@ -106,8 +106,8 @@ def create_parser():
     return parser
 
 def render_params(blast_parquet, fasta_file, seq_meta_file, output_dir, efi_config,
-        db_version, job_id, efi_db, mode, ssn_name, job_name, maxfull,
-        filter_parameter=None, filter_min_val, min_length=None, max_length=None,
+        db_version, job_id, efi_db, mode, ssn_name, job_name, maxfull, filter_min_val,
+        filter_parameter=None, min_length=None, max_length=None,
         **kwargs: dict):
     params = {
         "blast_parquet": blast_parquet,

--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -15,9 +15,7 @@ params {
     duckdb_threads = 1
     num_accession_shards = 64
     import_blast_fasta_db = null
-    accessions_file = null
-    uploaded_fasta_file = null
-    blast_query_file = null
+    input_file = null
     filter = null
     // GenerateSSN parameters
     filter_parameter = "alignment_score"

--- a/pipelines/est/subworkflows/import.nf
+++ b/pipelines/est/subworkflows/import.nf
@@ -29,22 +29,22 @@ process get_source_ids {
     if (params.import_mode == "blast") {
         // blast_hits.tab is provided as an output to the user
         """
-        blastall -p blastp -i ${params.blast_query_file} -d ${params.import_blast_fasta_db} -m 8 -e ${params.import_blast_evalue} -b ${params.import_blast_num_matches} -o init_blast.out
+        blastall -p blastp -i ${params.input_file} -d ${params.import_blast_fasta_db} -m 8 -e ${params.import_blast_evalue} -b ${params.import_blast_num_matches} -o init_blast.out
         if [[ -s init_blast.out ]]; then
             awk '! /^#/ {print \$2"\t"\$11}' init_blast.out | sort -k2nr > blast_hits.tab
         else
             echo "BLAST did not return any matches.  Verify that the sequence is a protein and not a nucleotide sequence."
             exit 1
         fi
-        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --blast-output init_blast.out --blast-query ${params.blast_query_file}
+        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --blast-output init_blast.out --blast-query ${params.input_file}
         """
     } else if (params.import_mode == "accessions") {
         """
-        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --accessions ${params.accessions_file}
+        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --accessions ${params.input_file}
         """
     } else if (params.import_mode == "fasta") {
         """
-        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --fasta ${params.uploaded_fasta_file} --sequence-mapping-file seq_mapping.tab
+        perl $projectDir/import/get_sequence_ids.pl $common_args $family_args --fasta ${params.input_file} --sequence-mapping-file seq_mapping.tab
         """
     } else if (params.import_mode == "family") {
         """
@@ -101,7 +101,7 @@ process cat_fasta_files {
     if (params.import_mode == "blast") {
         """
         $cat_cmd
-        perl $projectDir/import/append_blast_query.pl --blast-query-file ${params.blast_query_file} --output-sequence-file all_sequences.fasta
+        perl $projectDir/import/append_blast_query.pl --blast-query-file ${params.input_file} --output-sequence-file all_sequences.fasta
         """
     } else {
         cat_cmd
@@ -116,7 +116,7 @@ process import_fasta {
     output:
         path "imported_sequences.fasta", emit: "fasta_file"
     """
-    perl $projectDir/import/import_fasta.pl --uploaded-fasta ${params.uploaded_fasta_file} --sequence-mapping-file ${seq_mapping} --output-sequence-file imported_sequences.fasta
+    perl $projectDir/import/import_fasta.pl --uploaded-fasta ${params.input_file} --sequence-mapping-file ${seq_mapping} --output-sequence-file imported_sequences.fasta
     """
 }
 

--- a/tests/modules/02a_est_blast.sh
+++ b/tests/modules/02a_est_blast.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/02b_est_blast_add_family.sh
+++ b/tests/modules/02b_est_blast_add_family.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --families $family
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --families $family
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/02f_est_blast_uniref50_add_family.sh
+++ b/tests/modules/02f_est_blast_uniref50_add_family.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-fasta-db $EFI_BLAST_IMPORT_FASTA_DB --families $family --sequence-version uniref50
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-fasta-db $EFI_BLAST_IMPORT_FASTA_DB --families $family --sequence-version uniref50
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/03a_est_fasta.sh
+++ b/tests/modules/03a_est_fasta.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/03i_est_fasta_filter_family.sh
+++ b/tests/modules/03i_est_fasta_filter_family.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --filter family=PF07476
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --filter family=PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/04a_est_accession.sh
+++ b/tests/modules/04a_est_accession.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/04k_est_accession_filter_family.sh
+++ b/tests/modules/04k_est_accession_filter_family.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter family=PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter family=PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/04l_est_accession_filter_family_fail_empty.sh
+++ b/tests/modules/04l_est_accession_filter_family_fail_empty.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter family=PF05544
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter family=PF05544
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/04m_est_accession_domain.sh
+++ b/tests/modules/04m_est_accession_domain.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region domain --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region domain --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/02c_est_blast_filter_fragment.sh
+++ b/tests/modules/extended/02c_est_blast_filter_fragment.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --filter fragments
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --filter fragments
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/02d_est_blast_filter_taxonomy.sh
+++ b/tests/modules/extended/02d_est_blast_filter_taxonomy.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --filter predef-filter=bacteria
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --filter predef-filter=bacteria
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/02e_est_blast_add_family_filter_fragment.sh
+++ b/tests/modules/extended/02e_est_blast_add_family_filter_fragment.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --families $family --filter fragments
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --families $family --filter fragments
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/02g_est_blast_uniref50.sh
+++ b/tests/modules/extended/02g_est_blast_uniref50.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-fasta-db $EFI_BLAST_IMPORT_FASTA_DB --sequence-version uniref50
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-fasta-db $EFI_BLAST_IMPORT_FASTA_DB --sequence-version uniref50
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/02h_est_blast_uniref50_filter_fragment.sh
+++ b/tests/modules/extended/02h_est_blast_uniref50_filter_fragment.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-fasta-db $EFI_BLAST_IMPORT_FASTA_DB --sequence-version uniref50 --filter fragments
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-fasta-db $EFI_BLAST_IMPORT_FASTA_DB --sequence-version uniref50 --filter fragments
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/02i_est_blast_import_args.sh
+++ b/tests/modules/extended/02i_est_blast_import_args.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --blast-query-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-2 --import-blast-fasta-db $EFI_DB_NAME
+./bin/create_est_nextflow_params.py blast --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_BLAST_SEQ --nextflow-config $CONFIG_FILE --import-blast-num-matches 250 --import-blast-evalue 1e-2 --import-blast-fasta-db $EFI_DB_NAME
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/03c_est_fasta_add_family.sh
+++ b/tests/modules/extended/03c_est_fasta_add_family.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --families $family
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --families $family
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/03d_est_fasta_filter_fragment.sh
+++ b/tests/modules/extended/03d_est_fasta_filter_fragment.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --filter fragments
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --filter fragments
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/03e_est_fasta_filter_taxonomy.sh
+++ b/tests/modules/extended/03e_est_fasta_filter_taxonomy.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --filter predef-filter=bacteria
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --filter predef-filter=bacteria
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/03f_est_fasta_uniref50.sh
+++ b/tests/modules/extended/03f_est_fasta_uniref50.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --sequence-version uniref50
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --sequence-version uniref50
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/03g_est_fasta_add_family_filter_fragment.sh
+++ b/tests/modules/extended/03g_est_fasta_add_family_filter_fragment.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --families $family --filter fragments
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --families $family --filter fragments
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/03h_est_fasta_uniref50_add_family.sh
+++ b/tests/modules/extended/03h_est_fasta_uniref50_add_family.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --fasta-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --families $family --sequence-version uniref50
+./bin/create_est_nextflow_params.py fasta --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_FASTA_FILE --nextflow-config $CONFIG_FILE --families $family --sequence-version uniref50
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04c_est_accession_uniref90.sh
+++ b/tests/modules/extended/04c_est_accession_uniref90.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --sequence-version uniref90
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --sequence-version uniref90
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04d_est_accession_filter_fragment.sh
+++ b/tests/modules/extended/04d_est_accession_filter_fragment.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fragments
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fragments
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04e_est_accession_filter_taxonomy.sh
+++ b/tests/modules/extended/04e_est_accession_filter_taxonomy.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter predef-filter=bacteria
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter predef-filter=bacteria
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04f_est_accession_fraction.sh
+++ b/tests/modules/extended/04f_est_accession_fraction.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fraction=10
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fraction=10
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04g_est_accession_add_family_filter_fragment.sh
+++ b/tests/modules/extended/04g_est_accession_add_family_filter_fragment.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --families $family --filter fragments
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --families $family --filter fragments
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04h_est_accession_uniref50_add_family.sh
+++ b/tests/modules/extended/04h_est_accession_uniref50_add_family.sh
@@ -11,7 +11,7 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --families $family --sequence-version uniref50
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --families $family --sequence-version uniref50
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04i_est_accession_uniref90_fraction.sh
+++ b/tests/modules/extended/04i_est_accession_uniref90_fraction.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fraction=10 --sequence-version uniref90
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fraction=10 --sequence-version uniref90
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04j_est_accession_uniref90_filter_fragment.sh
+++ b/tests/modules/extended/04j_est_accession_uniref90_filter_fragment.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fraction=10 --sequence-version uniref90
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --filter fraction=10 --sequence-version uniref90
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04n_est_accession_domain_nterminal.sh
+++ b/tests/modules/extended/04n_est_accession_domain_nterminal.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region n-terminal --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region n-terminal --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME

--- a/tests/modules/extended/04o_est_accession_domain_cterminal.sh
+++ b/tests/modules/extended/04o_est_accession_domain_cterminal.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --accessions-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region c-terminal --domain-family PF07476
+./bin/create_est_nextflow_params.py accessions --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --input-file $EFI_TEST_ACC_FILE --nextflow-config $CONFIG_FILE --domain --domain-region c-terminal --domain-family PF07476
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --filter-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME


### PR DESCRIPTION
Implements the single parameter used to cover the input files for the BLAST, ACCESSIONS, and FASTA input modes for the est.nf workflow. This cleans up the parameter namespace but will require updates on KBase and job_manager code bases.