### PR TITLE
Remove urllib3

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -39,5 +39,4 @@ dependencies:
       - tabulate==0.9.0
       - tomli==2.0.1
       - tzdata==2024.1
-      - urllib3==2.2.1
       - igraph==0.11.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,5 +43,4 @@ sphinxcontrib-spelling==8.0.0
 tabulate==0.9.0
 tomli==2.0.1
 tzdata==2024.1
-urllib3==2.2.1
 igraph==0.11.6


### PR DESCRIPTION
Remove an unused python module that has a security risk. 

Clean up of the python requirements should happen at some point to decrease the software footprint of the backend environment.