### PR TITLE
257 - cd-hit memory allocation limit should be parameter controlled

### DIFF
--- a/bin/create_est_nextflow_params.py
+++ b/bin/create_est_nextflow_params.py
@@ -21,6 +21,7 @@ def add_args(parser: argparse.ArgumentParser):
     common_parser.add_argument("--accession-shards", type=int, help="Number of files to split Accessions list into. File is split so that sequence retrieval can be parallelized")
     common_parser.add_argument("--fasta-db", type=str, required=True, help="FASTA file or BLAST database to retrieve sequences from")
     common_parser.add_argument("--multiplex", action="store_true", help="Use CD-HIT to reduce the number of sequences used in analysis")
+    common_parser.add_argument("--cdhit-memory-limit", type=int, help="Hard limit to CD-HIT memory usage. Units of MB.")
     common_parser.add_argument("--blast-num-matches", type=int, help="Maximum number of matches returned by BLAST for the all-by-all computation")
     common_parser.add_argument("--blast-evalue", help="Cutoff E value to use in all-by-all BLAST")
     common_parser.add_argument("--sequence-version", type=str, choices=["uniprot", "uniref90", "uniref50"])
@@ -112,7 +113,8 @@ def create_parser() -> argparse.ArgumentParser:
 
 def render_params(output_dir, import_mode, sequence_version, job_id, efi_config, fasta_db, efi_db,
                   duckdb_memory_limit=None, duckdb_threads=None, fasta_shards=None,
-                  accession_shards=None, blast_num_matches=None, multiplex=None,
+                  accession_shards=None, blast_num_matches=None,
+                  multiplex=None, cdhit_memory_limit=None,
                   blast_evalue=None, domain=None, families=None, sequence_filter=None,
                   input_file=None, import_blast_fasta_db=None, import_blast_num_matches=None,
                   import_blast_evalue=None, domain_region=None, domain_family=None,
@@ -131,6 +133,7 @@ def render_params(output_dir, import_mode, sequence_version, job_id, efi_config,
         "import_mode": import_mode,
         "filter": sequence_filter,
         "multiplex": multiplex,
+        "cdhit_memory_limit": cdhit_memory_limit,
         "blast_num_matches": blast_num_matches,
         "blast_evalue": blast_evalue,
         "sequence_version": sequence_version,

--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -13,6 +13,7 @@ params {
     num_fasta_shards = 128
     duckdb_memory_limit = "8GB"
     duckdb_threads = 1
+    cdhit_memory_limit = 10000	// units: MB
     num_accession_shards = 64
     import_blast_fasta_db = null
     input_file = null

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -36,7 +36,7 @@ process multiplex {
         path "sequences.fasta", emit: "fasta_file"
         path "sequences.fasta.clstr", emit: "clusters"
     """
-    cd-hit -d 0  -c 1 -s 1 -i $fasta_file -o sequences.fasta -M 10000
+    cd-hit -d 0  -c 1 -s 1 -i $fasta_file -o sequences.fasta -M "${params.cdhit_memory_limit}"
     """
 }
 


### PR DESCRIPTION
As the title suggests, the currently-used `cd-hit` call has a hard-set memory allocation limit of 10 GB. This limit may cause issues for shared compute resources where 10 GB is beyond the allocated memory for the `nextflow run` or subprocess job. 

This PR adds a nextflow parameter `cdhit_memory_limit` with a default value of 10 GB (10000, assumed units of MB) set in the `EST/conf/default_params.config` file. The default value can be overwritten by the user or altered to work best with whatever implementation/deployment environment.

See CD-HIT documentation: https://home.cc.umanitoba.ca/~psgendb/doc/cd-hit/cdhit-user-guide.pdf for a somewhat incomplete presentation of how -M argument is used in the cd-hit software.

Closes #257 