### PR TITLE
33 cluster analysis WIP - refactor length histogram code

### DIFF
--- a/bin/create_clusteranalysis_nextflow_params.py
+++ b/bin/create_clusteranalysis_nextflow_params.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import json
+import os
+
+import shared_args
+
+NXF_SCRIPT = "pipelines/clusteranalysis/clusteranalysis.nf"
+
+def add_args(parser: argparse.ArgumentParser):
+    """
+    Add arguments for Cluster Analysis SSN pipeline to ``parser``
+    """
+    parser.add_argument("--ssn-input", required=True, type=str, help="The SSN file to color, XGMML or zipped XGMML")
+    parser.add_argument("--fasta-db", type=str, required=True, help="FASTA file or BLAST database to retrieve sequences from")
+    parser.add_argument("--max-msa-seq", type=int, required=False, help="The maximum number of sequences to use when running the multiple sequence alignment; clusters larger than this number will be resampled to this value for the MSA")
+    parser.add_argument("--min-msa-seq", type=int, required=False, help="The minimum number of sequences required for running the multiple sequence alignment; clusters smaller than this number will be excluded")
+    parser.add_argument("--weblogo", action=argparse.BooleanOptionalAction, default=True, help="Generate a weblogo for each cluster (on by default)")
+    parser.add_argument("--hmms", action=argparse.BooleanOptionalAction, default=True, help="Generate a HMM and Skylign data for each cluster (on by default)")
+    parser.add_argument("--length-histo", action=argparse.BooleanOptionalAction, default=True, help="Generate length histograms for each cluster (on by default)")
+    parser.add_argument("--compute-cons-res", action=argparse.BooleanOptionalAction, default=False, help="Generate consensus residues each cluster (on by default)")
+    parser.add_argument("--residues", type=str, help="If --compute-cons-res is specified, then the conserved residue calculation will be performed for these comma-separated amino acid codes")
+    parser.add_argument("--pid-thresholds", type=str, help="If --compute-cons-res is specified, then the conserved residues will be calculated at the given comma-separated list of percent identities")
+    shared_args.add_args(parser)
+
+def check_args(args: argparse.Namespace) -> argparse.Namespace:
+    """
+    Validate arguments and test file paths and rewrite them to be absolute
+    """
+    fail = False
+
+    # Check for shared args validity
+    validated_args = shared_args.check_args(args)
+    if validated_args is None:
+        fail = True
+    else:
+        args = validated_args
+
+    if not os.path.exists(args.ssn_input):
+        print(f"SSN Input file '{args.ssn_input}' does not exist")
+        fail = True
+    
+    if len(glob.glob(f"{args.fasta_db}.*")) == 0:
+        print(f"FASTA database '{args.fasta_db}' not found")
+        fail = True
+
+    if args.workflow_def is None:
+        args.workflow_def = os.path.abspath(NXF_SCRIPT)
+
+    # Consensus residue computation is optional, but if specified it requires two additional arguments
+    if args.compute_cons_res:
+        if not args.residues or not args.pid_thresholds:
+            print(f"Both --residues and --pid-threshold must be passed when --compute-cons-res is specified")
+            fail = True
+
+        if args.pid_thresholds:
+            try:
+                pid_list = [float(x.strip()) for x in args.pid_thresholds.split(',')]
+                if any(x < 0 or x > 100 for x in pid_list):
+                    print(f"--pid-threshold values must be >= 0 and <= 100")
+                    fail = True
+                args.pid_thresholds = pid_list
+            except ValueError:
+                print(f"--pid-threshold must be a comma-separated list of percentages from 0-100")
+                fail = True
+
+        if args.residues:
+            r_list = args.residues.split(',')
+            args.residues = r_list
+    else:
+        args.residues = ""
+        args.pid_thresholds = []
+
+    if fail:
+        print("Failed to render params template")
+        exit(1)
+    else:
+        args.ssn_input = os.path.abspath(args.ssn_input)
+        args.fasta_db = os.path.abspath(args.fasta_db)
+        return args
+    
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render params.yml for Color SSN nextflow pipeline")
+    add_args(parser)
+    return parser
+
+def render_params(ssn_input, efi_config, efi_db, fasta_db, output_dir,
+        max_msa_seq, min_msa_seq, weblogo, hmms, length_histo,
+        compute_cons_res, residues, pid_thresholds,
+        **kwargs: dict):
+    params = {
+        "final_output_dir": output_dir,
+        "ssn_input": ssn_input,
+        "fasta_db": fasta_db,
+        "efi_config": efi_config,
+        "efi_db": efi_db,
+        "max_msa_sequences": max_msa_seq,
+        "min_msa_sequences": min_msa_seq,
+        "make_weblogos": weblogo,
+        "make_hmms": hmms,
+        "make_length_histograms": length_histo,
+        "compute_conserved_residues": compute_cons_res,
+        "conserved_residues": residues,
+        "pid_thresholds": pid_thresholds,
+    }
+
+    # Handle kwargs dict, assuming each entry is a parameter to be added to params
+    params.update(kwargs)
+
+    # Remove parameter keys with None values
+    params = {key: value for key, value in params.items() if value != None}
+
+    params_file = os.path.join(output_dir, shared_args.PARAMS_NAME)
+    with open(params_file, "w") as f:
+        json.dump(params, f, indent=4)
+    print(f"Wrote params to '{params_file}'")
+    return params_file
+
+if __name__ == "__main__":
+    args = check_args(create_parser().parse_args())
+    params_file = render_params(**vars(args))
+    shared_args.save_run_script(args, workflow_def=args.workflow_def, params_file=params_file)
+

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -43,7 +43,7 @@ process visualize_length_histograms {
         path '*.png', emit: plots
     """
     base_name=\$(basename "${length_histogram_file}" .histogram.txt)
-    python $projectDir/visualization/plot_length_data.py --lengths $length_histogram_file --job-id ${params.job_id} --frac 1 --plot-filename length_histogram_\${base_name} --output-type png --proxies sm:48
+    python $projectDir/../shared/python/plot_length_data.py --lengths $length_histogram_file --job-id ${params.job_id} --frac 1 --plot-filename length_histogram_\${base_name} --output-type png --proxies sm:48
     python $projectDir/visualization/export_length_histogram_json.py --lengths $length_histogram_file --frac 1 --output-json-filename length_histogram_\${base_name}.json 
     """
 }

--- a/pipelines/shared/python/compute_length_histogram.py
+++ b/pipelines/shared/python/compute_length_histogram.py
@@ -24,43 +24,45 @@ def parse_fasta(file_handle: TextIO) -> Iterator[Tuple[str, str]]:
     if header:
         yield (header, ''.join(sequence))
 
-def parse_accession_table(accession_table: str, seq_type: str) -> Set[str]:
+def parse_file(input_file: str, target_col: int, has_header_line: bool = True) -> Set[str]:
     """
-    Parses a three-column accession table file and gets the list of sequences that correspond
-    to the given sequence type (e.g. uniprot, uniref90, uniref50).  The table file has a header
-    column.
+    Parses a file and extracts IDs from the given column index. The file can have an optional header column.
     """
     ids = set()
-    col_map = {'uniprot': 0, 'uniref90': 1, 'uniref50': 2}
-    target_col = col_map[seq_type]
 
     try:
-        with open(accession_table, 'r') as fh:
-            next(fh)
+        with open(input_file, 'r') as fh:
+            if has_header_line:
+                next(fh)
             for line in fh:
-                parts = line.strip().split('\t')
-                if len(parts) < 3:
-                    continue
-                
-                uniprot_id = parts[0]
-                
-                # For 'uniprot' type, we consider all IDs in the first column.
-                if seq_type == 'uniprot':
-                    ids.add(uniprot_id)
-                # For 'uniref' types, we only add the UniProt ID if the corresponding
-                # UniRef column is not empty.
-                elif parts[target_col]:
-                    ids.add(uniprot_id)
+                parts = line.split('\t')
+                if len(parts) > target_col:
+                    val = parts[target_col].strip()
+                    if val:
+                        ids.add(val)
 
     except FileNotFoundError:
-        print(f"Error: Accession table file not found at '{accession_table}'", file=sys.stderr)
+        print(f"Error: input ID file not found at '{input_file}'", file=sys.stderr)
         sys.exit(1)
 
     return ids
 
-def compute_sequence_lengths(fasta_file: str, valid_ids: Set[str]) -> List[int]:
+def parse_accession_table(accession_table: str, seq_type: str) -> Set[str]:
     """
-    Process the FASTA file and collect lengths
+    Parses a standard three-column accession table file output by the 'est' pipeline, and gets
+    the list of sequences that correspond to the given sequence type (e.g. uniprot, uniref90,
+    uniref50). The table file has a header column.
+    """
+    col_map = {'uniprot': 0, 'uniref90': 1, 'uniref50': 2}
+    target_col = col_map[seq_type]
+
+    return parse_file(accession_table, target_col, True)
+
+def compute_sequence_lengths(fasta_file: str, valid_ids: Set[str] = None) -> List[int]:
+    """
+    Process the FASTA file and collect lengths. If 'valid_ids' is a Set, then only sequences
+    with IDs in the Set are included in the output. If 'valid_ids' is None, then all
+    sequences are included.
     """
     sequence_lengths = []
     try:
@@ -68,12 +70,13 @@ def compute_sequence_lengths(fasta_file: str, valid_ids: Set[str]) -> List[int]:
             for header, sequence in parse_fasta(fh):
                 include_sequence = False
 
-                # Include the sequence if it starts with 'ZZ' (no UniProt match was found for the header)
+                # Include the sequence if it starts with 'ZZ' (e.g. the input to the EST pipeline
+                # was a FASTA file that didn't have UniProt IDs in the header).
                 if header.startswith('ZZ'):
                     include_sequence = True
                 
-                # Include if the UniProt ID is in our set of valid IDs.
-                elif header in valid_ids:
+                # Include if the ID is in our set of valid IDs.
+                elif valid_ids == None or header in valid_ids:
                     include_sequence = True
 
                 if include_sequence:
@@ -85,20 +88,25 @@ def compute_sequence_lengths(fasta_file: str, valid_ids: Set[str]) -> List[int]:
 
     return sequence_lengths
 
-def main(fasta_file: str, accession_table: str, seq_type: str, output_file: str):
+def compute_histogram(fasta_file: str, output_file: str, accession_table: str = None, seq_type: str = None):
     """
-    Computes a length histogram for sequences based on specified criteria.
+    Computes a length histogram for sequences. If an 'accession_table' file is provided, that file
+    is parsed to obtain a list of IDs to use for generating the length histogram.
     """
-    if seq_type not in ['uniprot', 'uniref90', 'uniref50']:
-        print(f"Error: Invalid sequence type '{seq_type}'. Must be one of 'uniprot', 'uniref90', 'uniref50'.", file=sys.stderr)
-        sys.exit(1)
 
-    valid_ids = parse_accession_table(accession_table, seq_type)
+    # For a log message
+    seq_type_str = f" for type '{seq_type}'" if seq_type else ""
+
+    # None == use all sequences in fasta
+    if accession_table and seq_type:
+        valid_ids = parse_accession_table(accession_table, seq_type)
+    else:
+        valid_ids = None
 
     sequence_lengths = compute_sequence_lengths(fasta_file, valid_ids)
 
     if not sequence_lengths:
-        print(f"Warning: No sequences were selected for histogram generation for type '{seq_type}'. Output will be empty.", file=sys.stderr)
+        print(f"Warning: No sequences were selected for histogram generation{seq_type_str}. Output will be empty.", file=sys.stderr)
 
     length_counts = Counter(sequence_lengths)
 
@@ -108,17 +116,16 @@ def main(fasta_file: str, accession_table: str, seq_type: str, output_file: str)
         for length, count in sorted(length_counts.items()):
             f_out.write(f"{length}\t{count}\n")
     
-    print(f"Successfully wrote histogram for '{seq_type}' to '{output_file}'")
+    print(f"Successfully wrote histogram{seq_type_str} to '{output_file}'")
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Compute a length histogram for sequences in a FASTA file.")
     parser.add_argument('--fasta-file', required=True, help="Path to the input FASTA file.")
-    parser.add_argument('--accession-table', required=True, help="Path to the 3-column accession table file.")
-    parser.add_argument('--seq-type', required=True, choices=['uniprot', 'uniref90', 'uniref50'], help="The sequence type to generate the histogram for.")
     parser.add_argument('--output-file', required=True, help="Path to write the output histogram file.")
-    
+    parser.add_argument('--accession-table', required=False, help="Path to accession table file, containing three columns (uniprot, uniref90, uniref50).  If not specified, then all of the sequences in the FASTA file are used in the length histogram computation.")
+    parser.add_argument('--seq-type', required=False, choices=['uniprot', 'uniref90', 'uniref50'], help="The sequence type to generate the histogram for; choosing 'uniprot' is equivalent to choosing the first column.")
+
     args = parser.parse_args()
     
-    main(args.fasta_file, args.accession_table, args.seq_type, args.output_file)
-
+    compute_histogram(args.fasta_file, args.output_file, args.accession_table, args.seq_type)

--- a/pipelines/shared/python/plot_length_data.py
+++ b/pipelines/shared/python/plot_length_data.py
@@ -17,7 +17,7 @@ def create_parser():
         required=True,
         help="Tab-separated file containing lengths and counts",
     )
-    parser.add_argument("--job-id", required=True, help="Job ID number for BLAST output file")
+    parser.add_argument("--job-id", required=False, help="Job ID number for BLAST output file")
     parser.add_argument("--frac", type=float, default=1, help="Percent of length values to include in plot")
     parser.add_argument(
         "--plot-filename",
@@ -25,6 +25,7 @@ def create_parser():
         required=True,
         help="Filename, without extension, to write the plots to",
     )
+    parser.add_argument("--title", required=False, type=str, default="", help="Set the plot title (if provided, --title-extra and --job-id are ignored)")
     parser.add_argument("--title-extra", type=str, default="", help="Extra text to include plot title")
     parser.add_argument("--output-type", type=str, default="png", choices=["png", "svg", "pdf"])
     parser.add_argument(
@@ -51,7 +52,7 @@ def parse_args(parser):
         return args
 
 
-def main(lengths_file, job_id, frac, output_filename, title_extra, output_filetype, proxies):
+def main(lengths_file, frac, output_filename, plot_title, output_filetype, proxies):
     print(f"Reading lengths from '{lengths_file}'")
     df = count_lengths(lengths_file, frac)
 
@@ -73,7 +74,7 @@ def main(lengths_file, job_id, frac, output_filename, title_extra, output_filety
         fig,
         axs,
         df["length"],
-        f"Number of Sequences at Each Length for Job ID {job_id} {title_extra}",
+        plot_title,
         "Sequence Length",
         "Number of Sequences",
         output_filename,
@@ -82,15 +83,23 @@ def main(lengths_file, job_id, frac, output_filename, title_extra, output_filety
     )
     plt.close(fig)
 
+def get_plot_title(job_id, title, title_extra):
+    if title:
+        return title
+    else:
+        job_id_arg = f" for Job ID {job_id}" if job_id else ""
+        extra_arg = f" {title_extra}" if title_extra else ""
+        plot_title = f"Number of Sequences at Each Length{job_id_arg}{extra_arg}"
+        return plot_title
 
 if __name__ == "__main__":
     args = parse_args(create_parser())
+    plot_title = get_plot_title(args.job_id, args.title, args.title_extra)
     main(
         args.lengths,
-        args.job_id,
         args.frac,
         args.plot_filename,
-        args.title_extra,
+        plot_title,
         args.output_type,
         args.proxies,
     )

--- a/tests/modules/16a_cluster_analysis.sh
+++ b/tests/modules/16a_cluster_analysis.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+if [[ ! -e "$EFI_TEST_SSN_UNIPROT" ]]; then
+    echo "Test skipped; missing $EFI_TEST_SSN_UNIPROT"
+    exit 0
+fi
+
+TEST_RESULTS_DIR=$1
+CONFIG_FILE=$2
+
+self=$(basename "$0" .sh)
+OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
+
+rm -rf $OUTPUT_DIR
+
+./bin/create_clusteranalysis_nextflow_params.py --output-dir $OUTPUT_DIR --ssn-input $EFI_TEST_SSN_UNIPROT --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --nextflow-config $CONFIG_FILE \
+    --weblogo \
+    --hmms \
+    --length-histo \
+    --compute-cons-res \
+    --residues C,A \
+    --pid-thresholds 50,100
+#bash $OUTPUT_DIR/run_nextflow.sh
+


### PR DESCRIPTION
Refactor length histogram code for reuse in both est and cluster analysis pipelines.

* The entire title can be provided as an argument to the `plot_length_data.py` script, avoiding the requirement for a job ID (needed for cluster analysis plot generation)
* It is no longer required to pass an accession ID table file to `compute_length_histogram.py`. If this is not provided, then the length histogram is computed based on the FASTA file alone. This required a significant rewrite of the file.