### PR TITLE
Update shared color workflow to return SSN sequence as Nextflow value

### DIFF
--- a/docs/source/pipelines/shared/perl/ssn_to_id_list.rst
+++ b/docs/source/pipelines/shared/perl/ssn_to_id_list.rst
@@ -7,17 +7,19 @@ Usage
 
 	Usage: perl pipelines/shared/perl/ssn_to_id_list.pl --ssn <FILE> --edgelist <FILE>
 	    --index-seqid <FILE> --seqid-source-map <FILE> [--id-index <FILE>] [--ssn-sequences <VALUE>]
+	    [--sequence-type-file <VALUE>]
 	
 	Description:
 	    Parses an XGMML file to retrieve an edgelist and mapping info
 	
 	Options:
-	    --ssn                 path to XGMML (XML) SSN file
-	    --edgelist            path to an output edgelist file (two column space-separated file)
-	    --index-seqid         path to an output file mapping node index to XGMML nodeseqid (and optionally node size for UniRef/repnodes)
-	    --id-index            path to an output file mapping XGMML node ID to node index
-	    --seqid-source-map    path to an output file for mapping metanodes (e.g. RepNode or UniRef node) to UniProt nodes [optional]; the file is created regardless, but if the input IDs are UniProt the file is empty
-	    --ssn-sequences       optional path to an output FASTA file for saving sequences that were embedded in the SSN
+	    --ssn                   path to XGMML (XML) SSN file
+	    --edgelist              path to an output edgelist file (two column space-separated file)
+	    --index-seqid           path to an output file mapping node index to XGMML nodeseqid (and optionally node size for UniRef/repnodes)
+	    --id-index              path to an output file mapping XGMML node ID to node index
+	    --seqid-source-map      path to an output file for mapping metanodes (e.g. RepNode or UniRef node) to UniProt nodes [optional]; the file is created regardless, but if the input IDs are UniProt the file is empty
+	    --ssn-sequences         optional path to an output FASTA file for saving sequences that were embedded in the SSN
+	    --sequence-type-file    optional path to an output file containing the type of sequence that the SSN is based on
 
 Reference
 ---------
@@ -37,6 +39,7 @@ SYNOPSIS
 
    ssn_to_id_list.pl --ssn <FILE> --edgelist <FILE> --index-seqid <FILE>
        --seqid-source-map <FILE> [--id-index <FILE> --ssn-sequences <FILE>]
+       [--sequence-type-file <FILE>]
 
 
 
@@ -108,3 +111,8 @@ Arguments
 ``--ssn-sequences``
    Optional path to an output FASTA file that contains sequences that
    were embedded in the SSN.
+
+``--sequence-type-file``
+   Optional path to a file that will contain the sequence type (e.g. to
+   provide the sequence type to another process). The sequence type is
+   one of SEQ_UNIPROT, SEQ_UNIREF90, SEQ_UNIREF50, or SEQ_REPNODE.

--- a/pipelines/shared/nextflow/color_workflow.nf
+++ b/pipelines/shared/nextflow/color_workflow.nf
@@ -64,11 +64,13 @@ process get_ssn_id_info {
         path "index_seqid_map.txt", emit: "index_seqid_map"     // Maps node network ID to UniProt ID and the number of IDs in the metanode
         path "seqid_source_map.txt", emit: "seqid_source_map"   // Maps metanode IDs to UniProt IDs
         path "ssn_sequences.fasta", emit: "ssn_sequences"       // Custom sequences that are embedded in the SSN
+        env SEQ_TYPE, emit: sequence_type                       // Type of sequences that the SSN is based on (uniprot, uniref90, uniref50)
 
     script:
     """
     perl $projectDir/../shared/perl/ssn_to_id_list.pl --ssn $ssn_file --edgelist edgelist.txt --index-seqid index_seqid_map.txt \
-        --seqid-source-map seqid_source_map.txt --ssn-sequences ssn_sequences.fasta
+        --seqid-source-map seqid_source_map.txt --ssn-sequences ssn_sequences.fasta --sequence-type-file sequence_type.txt
+    SEQ_TYPE=\$(cat sequence_type.txt)
     """
 }
 
@@ -270,6 +272,9 @@ workflow color_and_retrieve {
             .set { grouped_fasta_ch }
         zipped_fasta_dirs = zip_fasta_directories(grouped_fasta_ch)
 
+        // Convert to value channel
+        sequence_type_val = ssn_data.sequence_type.map { it.trim() }
+
     emit:
         ssn_file
         mapping_table = anno_tables.mapping_table
@@ -285,5 +290,6 @@ workflow color_and_retrieve {
         zipped_id_dirs
         zipped_fasta_dirs
         fasta_files
+        sequence_type = sequence_type_val
 }
 

--- a/pipelines/shared/perl/ssn_to_id_list.pl
+++ b/pipelines/shared/perl/ssn_to_id_list.pl
@@ -45,6 +45,12 @@ if ($opts->{ssn_sequences}) {
     saveSsnSequences($opts->{ssn_sequences}, $metadata);
 }
 
+if ($opts->{sequence_type_file}) {
+    open my $fh, ">", $opts->{sequence_type_file} or die "Unable to write to sequence type file '$opts->{sequence_type_file}': $!";
+    $fh->print($metanodeType);
+    close $fh;
+}
+
 
 
 
@@ -209,6 +215,7 @@ sub validateAndProcessOptions {
     $optParser->addOption("id-index=s", 0, "path to an output file mapping XGMML node ID to node index", OPT_FILE);
     $optParser->addOption("seqid-source-map=s", 1, "path to an output file for mapping metanodes (e.g. RepNode or UniRef node) to UniProt nodes [optional]; the file is created regardless, but if the input IDs are UniProt the file is empty", OPT_FILE);
     $optParser->addOption("ssn-sequences=s", 0, "optional path to an output FASTA file for saving sequences that were embedded in the SSN");
+    $optParser->addOption("sequence-type-file=s", 0, "optional path to an output file containing the type of sequence that the SSN is based on");
 
     if (not $optParser->parseOptions() or $optParser->wantHelp()) {
         print $optParser->printHelp();
@@ -231,6 +238,7 @@ C<ssn_to_id_list.pl> - gets network information from a SSN
 
     ssn_to_id_list.pl --ssn <FILE> --edgelist <FILE> --index-seqid <FILE>
         --seqid-source-map <FILE> [--id-index <FILE> --ssn-sequences <FILE>]
+        [--sequence-type-file <FILE>]
 
 =head2 DESCRIPTION
 
@@ -295,6 +303,11 @@ like this:
 Optional path to an output FASTA file that contains sequences that were
 embedded in the SSN.
 
-=back
+=item C<--sequence-type-file>
 
+Optional path to a file that will contain the sequence type (e.g. to provide
+the sequence type to another process).  The sequence type is one of SEQ_UNIPROT,
+SEQ_UNIREF90, SEQ_UNIREF50, or SEQ_REPNODE.
+
+=back
 


### PR DESCRIPTION
The cluster analysis pipeline requires a value indicating the original sequence type that the SSN is built from (e.g. UniProt, UniRef90, UniRef50).  This PR has changes that return this value from the shared color workflow.