### PR TITLE
Compute MSA and related processes using input SSN sequence type

### DIFF
--- a/pipelines/clusteranalysis/clusteranalysis.nf
+++ b/pipelines/clusteranalysis/clusteranalysis.nf
@@ -9,9 +9,9 @@ workflow {
     // color_and_retrieve workflow
     color_work = color_and_retrieve()
 
-    analysis_fasta_ch = prepare_fasta(color_work.fasta_files)
+    prepared_fasta_ch = prepare_fasta(color_work.fasta_files, color_work.sequence_type)
 
-    align_and_analyze(analysis_fasta_ch)
+    align_and_analyze(prepared_fasta_ch.analysis_fasta)
 
-    histograms = make_histograms(analysis_fasta_ch)
+    histograms = make_histograms(prepared_fasta_ch.color_fasta)
 }

--- a/pipelines/clusteranalysis/subworkflows/length_histograms.nf
+++ b/pipelines/clusteranalysis/subworkflows/length_histograms.nf
@@ -5,15 +5,15 @@ process make_histograms {
     publishDir "${params.final_output_dir}/data/${type}/histo", mode: "copy"
 
     input:
-        tuple val(type), val(id), path(fasta)
+        tuple val(type), val(id), path(fasta), val(sequence_type)
 
     output:
-        tuple val(type), val(id), path("length_histogram*.png")
+        tuple val(type), val(id), path("length_histogram*.png"), val(sequence_type)
 
     script:
     """
     python $projectDir/../shared/python/compute_length_histogram.py --fasta-file ${fasta} --output-file histogram.txt
-    python $projectDir/../shared/python/plot_length_data.py --lengths histogram.txt --title "Number of Sequences at Each Length Full-(${id})" --frac 1 --plot-filename length_histogram_${id} --output-type png --proxies sm:48
+    python $projectDir/../shared/python/plot_length_data.py --lengths histogram.txt --title "Number of Sequences at Each Length Full (${id}, ${sequence_type})" --frac 1 --plot-filename length_histogram_${id} --output-type png --proxies sm:48
     """
 }
 

--- a/pipelines/clusteranalysis/subworkflows/msa.nf
+++ b/pipelines/clusteranalysis/subworkflows/msa.nf
@@ -5,10 +5,10 @@ process muscle5_align {
     publishDir "${params.final_output_dir}/data/${type}/msa", mode: "copy", pattern: "*.afa"
 
     input:
-        tuple val(type), val(id), path(fasta)
+        tuple val(type), val(id), path(fasta), val(seq_type), val(num_seq)
 
     output:
-        tuple val(type), val(id), path("*.afa"), emit: msa
+        tuple val(type), val(id), path("*.afa"), val(seq_type), val(num_seq), emit: msa
 
     script:
     """
@@ -38,10 +38,10 @@ process muscle3_align {
     }
 
     input:
-        tuple val(type), val(id), path(fasta)
+        tuple val(type), val(id), path(fasta), val(seq_type), val(num_seq)
 
     output:
-        tuple val(type), val(id), path("*.afa"), emit: msa
+        tuple val(type), val(id), path("*.afa"), val(seq_type), val(num_seq), emit: msa
 
     script:
     """
@@ -56,7 +56,7 @@ process build_hmms {
     publishDir "${params.final_output_dir}/data/${type}/hmms", mode: "copy", pattern: "*.json"
 
     input:
-        tuple val(type), val(id), path(msa)
+        tuple val(type), val(id), path(msa), val(seq_type), val(num_seq)
 
     output:
         path("*.hmm")
@@ -75,7 +75,7 @@ process make_weblogos {
     publishDir "${params.final_output_dir}/data/${type}/weblogos", mode: "copy", pattern: "*.png"
 
     input:
-        tuple val(type), val(id), path(msa)
+        tuple val(type), val(id), path(msa), val(seq_type), val(num_seq)
 
     output:
         path("*.png")
@@ -96,7 +96,7 @@ process run_clustal_omega {
     errorStrategy 'ignore'
 
     input:
-        tuple val(type), val(id), path(msa)
+        tuple val(type), val(id), path(msa), val(seq_type), val(num_seq)
 
     output:
         tuple val(type), path("*_pim.txt")

--- a/pipelines/clusteranalysis/subworkflows/prepare.nf
+++ b/pipelines/clusteranalysis/subworkflows/prepare.nf
@@ -3,19 +3,33 @@ process subset_fasta {
     tag "ca_sample_${id}"
 
     input:
-        tuple val(type), val(id), path(fasta)
+        tuple val(type), val(id), path(fasta), val(sequence_type), val(num_seq)
 
     output:
-        tuple val(type), val(id), path("*_subset.fasta")
+        tuple val(type), val(id), path("*_subset.fasta"), val(sequence_type), val(num_seq)
 
     script:
 
     """
-wget https://github.com/shenwei356/seqkit/releases/download/v2.8.2/seqkit_linux_amd64.tar.gz
-    tar -xvf seqkit_linux_amd64.tar.gz
     # --two-pass dramatically reduces memory usage for large files
     # -s 100 sets a fixed seed for reproducibility
-    ./seqkit sample --two-pass -n ${params.max_msa_sequences} -s 100 ${fasta} > ${id}_subset.fasta
+    seqkit sample --two-pass -n ${params.max_msa_sequences} -s 100 ${fasta} > ${id}_subset.fasta
+    """
+}
+
+process count_fasta {
+    tag "ca_count_fasta_${id}"
+
+    input:
+        tuple val(type), val(id), path(fasta), val(sequence_type)
+
+    output:
+        tuple val(type), val(id), path(fasta), val(sequence_type), env(COUNT)
+
+    script:
+
+    """
+    COUNT=\$(grep -c "^>" ${fasta})
     """
 }
 
@@ -23,11 +37,11 @@ process cdhit_reduce {
     tag "ca_cdhit_${id}"
 
     input:
-        tuple val(type), val(id), path(fasta)
+        tuple val(type), val(id), path(fasta), val(sequence_type)
 
     output:
         // We emit the same triplet structure so it can mix back easily later
-        tuple val(type), val(id), path("*_cdhit.fasta")
+        tuple val(type), val(id), path("*_cdhit.fasta"), val(sequence_type)
 
     script:
 
@@ -40,47 +54,56 @@ process cdhit_reduce {
 workflow prepare_fasta {
     take:
         color_fasta_files
+        sequence_type
 
     main:
 
         // STEP 1: COLLECT ALL SEQUENCES INTO ONE CHANNEL
 
-        // Add 'type' column to tuple
+        // Add cluster ID column to tuple
         color_fasta_ch = color_fasta_files
-            .filter { type, file -> !file.name.contains("_All.fasta") }     // Don't include the file with all sequences in the analysis
-            .filter { type, file -> !file.name.contains("singleton") }      // Don't include singletons in the analysis
-            .map { type, file ->
+            .filter { file_type, file -> !file.name.contains("_All.fasta") }     // Don't include the file with all sequences in the analysis
+            .filter { file_type, file -> !file.name.contains("singleton") }      // Don't include singletons in the analysis
+            .map { file_type, file ->
                 // Extract the filename without extension (e.g. "cluster_UniProt_Cluster_1")
                 def raw_id = file.simpleName 
                 // Clean up the ID to be just the cluster number
                 // This regex removes "cluster_UniProt_" from the front if present
                 def clean_id = raw_id.replaceAll(/^cluster_Uni(Prot|Ref90|Ref50)_/, '')
-                return tuple(type, clean_id, file)
+                return tuple(file_type, clean_id, file)
             }
+            .combine(sequence_type)
+
+        // Only use the files for the sequence file_type that was provided (e.g. if the input
+        // is UniRef50 SSN, then only use UniRef50 sequences)
+        color_fasta_ch.branch {
+            sequence_type_files:    it[0] == it[3]
+            ignored_files:          true
+        }.set { seq_type_fasta_ch }
 
         // STEP 2: APPLY CD-HIT TO REDUCE REDUNDANCY
 
-        // Split channel into branches, one needing CD-HIT and the other to pass through
-        color_fasta_ch.branch {
-            to_cdhit: it[0] == 'uniprot'
-            to_msa:   true
-        }.set { split_fasta_ch }
+        seq_type_fasta_ch.sequence_type_files.branch {
+            needs_reduction:    it[0] == 'uniprot'
+            skip_reduction:     true
+        }.set { reduction_set_ch }
 
-        // Reduce all sequences that are uniprot
-        cdhit_results = cdhit_reduce(split_fasta_ch.to_cdhit)
-
-        // Merge split channels
-        reduction_ch = split_fasta_ch.to_msa.mix(cdhit_results)
+        // Reduce all sequences that are uniprot by removing all sequences that are 100% identical over 100% of the length of the sequence
+        condensed_ch = cdhit_reduce(reduction_set_ch.needs_reduction)
+            .mix(reduction_set_ch.skip_reduction)
 
         // STEP 3: SAMPLE THE FASTA TO REDUCE SIZE FOR MUSCLE
 
+        // Count the number of fasta sequences in each file
+        counted_ch = count_fasta(condensed_ch)
+
         // Split channel into a branch that needs sampling, and one that doesn't
-        reduction_ch.branch {
+        counted_ch.branch {
             // Needs subsetting (Too big)
             // Check if max_msa_sequences is set AND file exceeds it
-            large: params.max_msa_sequences > 0 && it[2].countFasta() > params.max_msa_sequences
+            large: params.max_msa_sequences > 0 && it[4].toInteger() > params.max_msa_sequences
             // Don't need to subset
-            small: params.min_msa_sequences == 0 || it[2].countFasta() >= params.min_msa_sequences
+            small: params.min_msa_sequences == 0 || it[4].toInteger() >= params.min_msa_sequences
             // Exclude any files that are outside of the min/max range
             ignored: true
         }.set { split_sampled_ch }
@@ -94,5 +117,8 @@ workflow prepare_fasta {
         analysis_fasta_ch = sampled_ch.mix(split_sampled_ch.small)
 
     emit:
-        analysis_fasta_ch
+        // This will be for length histograms because we generate length histograms for every sequence type
+        color_fasta = color_fasta_ch
+        // This will be used for MSA, etc, and include the sequence type but only sequences in the input SSN (e.g. uniref)
+        analysis_fasta = analysis_fasta_ch
 }


### PR DESCRIPTION
- MSA, weblogo, HMM, and Clustal-Omega processes use input SSN sequence type (e.g. if SSN is UniRef50, UniRef50 sequences are used)
- In prior version all sequence types were processed
- Also, move computation of number of FASTA sequences into separate process; this previously occurred on the head node since the countFasta() function was in a workflow, so this was moved to a new process that counts the number of sequences