### PR TITLE
283 - Fix duckdb temp dir naming

### DIFF
--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -13,6 +13,7 @@ params {
     num_fasta_shards = 128
     duckdb_memory_limit = "8GB"
     duckdb_threads = 1
+    duckdb_temp_dir = "/scratch"
     cdhit_memory_limit = 10000	// units: MB
     num_accession_shards = 64
     import_blast_fasta_db = null

--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -13,7 +13,6 @@ params {
     num_fasta_shards = 128
     duckdb_memory_limit = "8GB"
     duckdb_threads = 1
-    duckdb_temp_dir = "/scratch/duckdb"
     cdhit_memory_limit = 10000	// units: MB
     num_accession_shards = 64
     import_blast_fasta_db = null

--- a/lib/pyEFI/pyEFI/sql_template_render.py
+++ b/lib/pyEFI/pyEFI/sql_template_render.py
@@ -1,10 +1,28 @@
 import argparse
 from io import TextIOWrapper
 import string
+import tempfile
 
 from typing import Any
 
-def create_sql_template_render_parser(sql_template_file_default: str, desc: str, sql_output_file="statements.sql", duckdb_mem_limit="4GB", duckdb_temp_dir="./duckdb") -> argparse.ArgumentParser:
+def get_temp_dir_name() -> str:
+    """
+    Use tempfile.TemporaryDirectory() to create a temp directory space, gather
+    the path for that space, and automatically delete the empty directory.
+    Return the path to duckdb during sql template rendering.
+    """
+    temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors = True)
+    temp_path = temp_dir.name
+    temp_dir.cleanup()
+    return temp_path
+
+def create_sql_template_render_parser(
+        sql_template_file_default: str,
+        desc: str,
+        duckdb_temp_dir: str,
+        sql_output_file: str = "statements.sql",
+        duckdb_mem_limit: str = "4GB"
+    ) -> argparse.ArgumentParser:
     """
     Returns an `<argparse.ArgumentParser>_` that parses the following
     options:
@@ -44,7 +62,9 @@ def create_sql_template_render_parser(sql_template_file_default: str, desc: str,
     parser.add_argument(
         "--duckdb-temp-dir",
         type=str,
-        default=duckdb_temp_dir,
+        # if left undefined, will create a randomly generated directory name in
+        # the system's defined temp space
+        default = get_temp_dir_name(),
         help="Location DuckDB should use for temporary files",
     )
     return parser

--- a/lib/pyEFI/pyEFI/sql_template_render.py
+++ b/lib/pyEFI/pyEFI/sql_template_render.py
@@ -2,19 +2,17 @@ import argparse
 from io import TextIOWrapper
 import string
 import tempfile
+import uuid
 
 from typing import Any
 
-def get_temp_dir_name() -> str:
+def get_temp_dir_name(tmp_path: str = tempfile.gettempdir()) -> str:
     """
     Use tempfile.TemporaryDirectory() to create a temp directory space, gather
     the path for that space, and automatically delete the empty directory.
     Return the path to duckdb during sql template rendering.
     """
-    temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors = True)
-    temp_path = temp_dir.name
-    temp_dir.cleanup()
-    return temp_path
+    return os.path.join(tmp_path, "duckdb-" + str(uuid.uuid4())[:8])
 
 def create_sql_template_render_parser(
         sql_template_file_default: str,

--- a/lib/pyEFI/pyEFI/sql_template_render.py
+++ b/lib/pyEFI/pyEFI/sql_template_render.py
@@ -1,24 +1,26 @@
 import argparse
 from io import TextIOWrapper
 import string
-import tempfile
-import uuid
+
+#import tempfile
+#import uuid
 
 from typing import Any
 
-def get_temp_dir_name(tmp_path: str = tempfile.gettempdir()) -> str:
-    """
-    Use tempfile.TemporaryDirectory() to create a temp directory space, gather
-    the path for that space, and automatically delete the empty directory.
-    Return the path to duckdb during sql template rendering.
-    """
-    return os.path.join(tmp_path, "duckdb-" + str(uuid.uuid4())[:8])
+#def get_temp_dir_name(tmp_path: str = ) -> str:
+#    """
+#    Use tempfile.TemporaryDirectory() to create a temp directory space, gather
+#    the path for that space, and automatically delete the empty directory.
+#    Return the path to duckdb during sql template rendering.
+#    """
+#    return os.path.join(tmp_path, "duckdb-" + str(uuid.uuid4())[:8])
 
 def create_sql_template_render_parser(
         sql_template_file_default: str,
         desc: str,
         sql_output_file: str = "statements.sql",
-        duckdb_mem_limit: str = "4GB"
+        duckdb_mem_limit: str = "4GB",
+        duckdb_temp_dir: str = "./duckdb"
     ) -> argparse.ArgumentParser:
     """
     Returns an `<argparse.ArgumentParser>_` that parses the following
@@ -59,9 +61,7 @@ def create_sql_template_render_parser(
     parser.add_argument(
         "--duckdb-temp-dir",
         type=str,
-        # if left undefined, will create a randomly generated directory name in
-        # the system's defined temp space
-        default = get_temp_dir_name(),
+        default = duckdb_temp_dir,
         help="Location DuckDB should use for temporary files",
     )
     return parser

--- a/lib/pyEFI/pyEFI/sql_template_render.py
+++ b/lib/pyEFI/pyEFI/sql_template_render.py
@@ -19,7 +19,6 @@ def get_temp_dir_name() -> str:
 def create_sql_template_render_parser(
         sql_template_file_default: str,
         desc: str,
-        duckdb_temp_dir: str,
         sql_output_file: str = "statements.sql",
         duckdb_mem_limit: str = "4GB"
     ) -> argparse.ArgumentParser:

--- a/lib/pyEFI/pyEFI/sql_template_render.py
+++ b/lib/pyEFI/pyEFI/sql_template_render.py
@@ -2,26 +2,9 @@ import argparse
 from io import TextIOWrapper
 import string
 
-#import tempfile
-#import uuid
-
 from typing import Any
 
-#def get_temp_dir_name(tmp_path: str = ) -> str:
-#    """
-#    Use tempfile.TemporaryDirectory() to create a temp directory space, gather
-#    the path for that space, and automatically delete the empty directory.
-#    Return the path to duckdb during sql template rendering.
-#    """
-#    return os.path.join(tmp_path, "duckdb-" + str(uuid.uuid4())[:8])
-
-def create_sql_template_render_parser(
-        sql_template_file_default: str,
-        desc: str,
-        sql_output_file: str = "statements.sql",
-        duckdb_mem_limit: str = "4GB",
-        duckdb_temp_dir: str = "./duckdb"
-    ) -> argparse.ArgumentParser:
+def create_sql_template_render_parser(sql_template_file_default: str, desc: str, sql_output_file: str = "statements.sql", duckdb_mem_limit: str = "4GB", duckdb_temp_dir: str = "./duckdb") -> argparse.ArgumentParser:
     """
     Returns an `<argparse.ArgumentParser>_` that parses the following
     options:
@@ -61,7 +44,7 @@ def create_sql_template_render_parser(
     parser.add_argument(
         "--duckdb-temp-dir",
         type=str,
-        default = duckdb_temp_dir,
+        default=duckdb_temp_dir,
         help="Location DuckDB should use for temporary files",
     )
     return parser

--- a/pipelines/est/condense/render_restore_sql_template.py
+++ b/pipelines/est/condense/render_restore_sql_template.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+import string
+
+from pyEFI import sql_template_render
+
+def add_custom_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--blast-parquet", type=str, help="Path to the condensed BLAST parquet file.")
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = sql_template_render.create_sql_template_render_parser(
+        "../templates/restore-template.sql",
+        "Render the DuckDB SQL template for restoring all blast edges from the condensed sequence set",
+        sql_output_file="restore.sql"
+    )
+    return parser
+
+def check_args(args: argparse.Namespace) -> argparse.Namespace:
+    if not os.path.exists(args.blast_parquet):
+        print(f"Input blast parquet file '{args.blast_parquet}' does not exist")
+        exit(1)
+    return args
+
+if __name__ == "__main__":
+    parser = create_parser()
+    add_custom_arguments(parser)
+    args = parser.parse_args()
+    args = check_args(args)
+    mapping = {
+        "mem_limit": args.duckdb_memory_limit,
+        "duckdb_temp_dir": args.duckdb_temp_dir,
+        "blast_parquet": args.blast_parquet
+    }
+    sql_template_render.render(args.sql_template, mapping, args.sql_output_file)

--- a/pipelines/est/subworkflows/all_by_all.nf
+++ b/pipelines/est/subworkflows/all_by_all.nf
@@ -28,7 +28,7 @@ process all_by_all_blast {
     python $projectDir/axa_blast/transcode_blast.py --blast-output ${frac}.tab
 
     # in each row, ensure that qseqid < sseqid lexicographically
-    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
     python $projectDir/axa_blast/render_prereduce_sql_template.py --blast-output ${frac}.tab.parquet --sql-template $projectDir/templates/prereduce-template.sql --output-file ${frac}.tab.sorted.parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file prereduce.sql
     duckdb < prereduce.sql
     """
@@ -65,7 +65,7 @@ process blastreduce {
         path "1.out.parquet"
 
     """
-    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
     python $projectDir/blastreduce/render_reduce_sql_template.py --blast-output $blast_files  --sql-template $projectDir/templates/reduce-template.sql --fasta-length-parquet $fasta_length_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file allreduce.sql
     duckdb < allreduce.sql
     """
@@ -80,7 +80,7 @@ process restore_condensed {
     output:
         path '1.out.parquet'
     """
-    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
     python $projectDir/condense/render_restore_sql_template.py --blast-parquet $blast_parquet --sql-template $projectDir/templates/restore-template.sql --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file restore.sql
     duckdb < restore.sql
     python $projectDir/condense/restore_condensed_sequences.py --condensed-blast condensed.out --restored-blast 1.out --cd-hit-cluster ${condensed}

--- a/pipelines/est/subworkflows/all_by_all.nf
+++ b/pipelines/est/subworkflows/all_by_all.nf
@@ -28,7 +28,8 @@ process all_by_all_blast {
     python $projectDir/axa_blast/transcode_blast.py --blast-output ${frac}.tab
 
     # in each row, ensure that qseqid < sseqid lexicographically
-    python $projectDir/axa_blast/render_prereduce_sql_template.py --blast-output ${frac}.tab.parquet --sql-template $projectDir/templates/prereduce-template.sql --output-file ${frac}.tab.sorted.parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file prereduce.sql
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    python $projectDir/axa_blast/render_prereduce_sql_template.py --blast-output ${frac}.tab.parquet --sql-template $projectDir/templates/prereduce-template.sql --output-file ${frac}.tab.sorted.parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file prereduce.sql
     duckdb < prereduce.sql
     """
 }
@@ -64,7 +65,8 @@ process blastreduce {
         path "1.out.parquet"
 
     """
-    python $projectDir/blastreduce/render_reduce_sql_template.py --blast-output $blast_files  --sql-template $projectDir/templates/reduce-template.sql --fasta-length-parquet $fasta_length_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file allreduce.sql
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    python $projectDir/blastreduce/render_reduce_sql_template.py --blast-output $blast_files  --sql-template $projectDir/templates/reduce-template.sql --fasta-length-parquet $fasta_length_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file allreduce.sql
     duckdb < allreduce.sql
     """
 }
@@ -78,7 +80,8 @@ process restore_condensed {
     output:
         path '1.out.parquet'
     """
-    python $projectDir/condense/render_restore_sql_template.py --blast-parquet $blast_parquet --sql-template $projectDir/templates/restore-template.sql --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file restore.sql
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    python $projectDir/condense/render_restore_sql_template.py --blast-parquet $blast_parquet --sql-template $projectDir/templates/restore-template.sql --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file restore.sql
     duckdb < restore.sql
     python $projectDir/condense/restore_condensed_sequences.py --condensed-blast condensed.out --restored-blast 1.out --cd-hit-cluster ${condensed}
     python $projectDir/condense/transcode_restored_blast.py --blast-output 1.out

--- a/pipelines/est/subworkflows/all_by_all.nf
+++ b/pipelines/est/subworkflows/all_by_all.nf
@@ -19,6 +19,7 @@ process all_by_all_blast {
         path frac
     output:
         path "${frac}.tab.sorted.parquet"
+    script:
     """
     # run blast to get similarity metrics
     blastall -p blastp -i $frac -d $blast_db_name -m 8 -e ${params.blast_evalue} -b ${params.blast_num_matches} -o ${frac}.tab
@@ -27,7 +28,7 @@ process all_by_all_blast {
     python $projectDir/axa_blast/transcode_blast.py --blast-output ${frac}.tab
 
     # in each row, ensure that qseqid < sseqid lexicographically
-    python $projectDir/axa_blast/render_prereduce_sql_template.py --blast-output ${frac}.tab.parquet --sql-template $projectDir/templates/prereduce-template.sql --output-file ${frac}.tab.sorted.parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --sql-output-file prereduce.sql
+    python $projectDir/axa_blast/render_prereduce_sql_template.py --blast-output ${frac}.tab.parquet --sql-template $projectDir/templates/prereduce-template.sql --output-file ${frac}.tab.sorted.parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file prereduce.sql
     duckdb < prereduce.sql
     """
 }
@@ -63,7 +64,7 @@ process blastreduce {
         path "1.out.parquet"
 
     """
-    python $projectDir/blastreduce/render_reduce_sql_template.py --blast-output $blast_files  --sql-template $projectDir/templates/reduce-template.sql --fasta-length-parquet $fasta_length_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --sql-output-file allreduce.sql
+    python $projectDir/blastreduce/render_reduce_sql_template.py --blast-output $blast_files  --sql-template $projectDir/templates/reduce-template.sql --fasta-length-parquet $fasta_length_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file allreduce.sql
     duckdb < allreduce.sql
     """
 }

--- a/pipelines/est/subworkflows/all_by_all.nf
+++ b/pipelines/est/subworkflows/all_by_all.nf
@@ -78,7 +78,8 @@ process restore_condensed {
     output:
         path '1.out.parquet'
     """
-    echo "SET memory_limit = '${params.duckdb_memory_limit}'; SET temp_directory = '${params.duckdb_temp_dir}-${task.index}'; SET threads TO 1; COPY (SELECT * FROM read_parquet('${blast_parquet}')) TO 'condensed.out' (FORMAT CSV, DELIMITER '\t', HEADER false);" | duckdb
+    python $projectDir/condense/render_restore_sql_template.py --blast-parquet $blast_parquet --sql-template $projectDir/templates/restore-template.sql --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file restore.sql
+    duckdb < restore.sql
     python $projectDir/condense/restore_condensed_sequences.py --condensed-blast condensed.out --restored-blast 1.out --cd-hit-cluster ${condensed}
     python $projectDir/condense/transcode_restored_blast.py --blast-output 1.out
     """

--- a/pipelines/est/subworkflows/all_by_all.nf
+++ b/pipelines/est/subworkflows/all_by_all.nf
@@ -27,7 +27,7 @@ process all_by_all_blast {
     python $projectDir/axa_blast/transcode_blast.py --blast-output ${frac}.tab
 
     # in each row, ensure that qseqid < sseqid lexicographically
-    python $projectDir/axa_blast/render_prereduce_sql_template.py --blast-output ${frac}.tab.parquet --sql-template $projectDir/templates/prereduce-template.sql --output-file ${frac}.tab.sorted.parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.hash} --sql-output-file prereduce.sql
+    python $projectDir/axa_blast/render_prereduce_sql_template.py --blast-output ${frac}.tab.parquet --sql-template $projectDir/templates/prereduce-template.sql --output-file ${frac}.tab.sorted.parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --sql-output-file prereduce.sql
     duckdb < prereduce.sql
     """
 }
@@ -63,7 +63,7 @@ process blastreduce {
         path "1.out.parquet"
 
     """
-    python $projectDir/blastreduce/render_reduce_sql_template.py --blast-output $blast_files  --sql-template $projectDir/templates/reduce-template.sql --fasta-length-parquet $fasta_length_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.hash} --sql-output-file allreduce.sql
+    python $projectDir/blastreduce/render_reduce_sql_template.py --blast-output $blast_files  --sql-template $projectDir/templates/reduce-template.sql --fasta-length-parquet $fasta_length_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --sql-output-file allreduce.sql
     duckdb < allreduce.sql
     """
 }
@@ -77,7 +77,7 @@ process restore_condensed {
     output:
         path '1.out.parquet'
     """
-    echo "SET memory_limit = '${params.duckdb_memory_limit}'; SET temp_directory = '${params.duckdb_temp_dir}-${task.hash}'; SET threads TO 1; COPY (SELECT * FROM read_parquet('${blast_parquet}')) TO 'condensed.out' (FORMAT CSV, DELIMITER '\t', HEADER false);" | duckdb
+    echo "SET memory_limit = '${params.duckdb_memory_limit}'; SET temp_directory = '${params.duckdb_temp_dir}-${task.index}'; SET threads TO 1; COPY (SELECT * FROM read_parquet('${blast_parquet}')) TO 'condensed.out' (FORMAT CSV, DELIMITER '\t', HEADER false);" | duckdb
     python $projectDir/condense/restore_condensed_sequences.py --condensed-blast condensed.out --restored-blast 1.out --cd-hit-cluster ${condensed}
     python $projectDir/condense/transcode_restored_blast.py --blast-output 1.out
     """

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -16,7 +16,7 @@ process compute_stats {
     python $projectDir/statistics/conv_ratio.py --blast-output $blast_parquet --fasta $fasta_file --output conv_ratio.json
 
     # compute boxplot stats and evalue.tab
-    python $projectDir/statistics/render_boxplotstats_sql_template.py --blast-output $blast_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --boxplot-stats-output boxplot_stats.parquet --evalue-output evalue.tab --sql-template $projectDir/templates/boxplotstats-template.sql --sql-output-file boxplotstats.sql
+    python $projectDir/statistics/render_boxplotstats_sql_template.py --blast-output $blast_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --boxplot-stats-output boxplot_stats.parquet --evalue-output evalue.tab --sql-template $projectDir/templates/boxplotstats-template.sql --sql-output-file boxplotstats.sql
     duckdb < boxplotstats.sql
     """
 }

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -16,7 +16,7 @@ process compute_stats {
     python $projectDir/statistics/conv_ratio.py --blast-output $blast_parquet --fasta $fasta_file --output conv_ratio.json
 
     # compute boxplot stats and evalue.tab
-    python $projectDir/statistics/render_boxplotstats_sql_template.py --blast-output $blast_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.hash} --boxplot-stats-output boxplot_stats.parquet --evalue-output evalue.tab --sql-template $projectDir/templates/boxplotstats-template.sql --sql-output-file boxplotstats.sql
+    python $projectDir/statistics/render_boxplotstats_sql_template.py --blast-output $blast_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --boxplot-stats-output boxplot_stats.parquet --evalue-output evalue.tab --sql-template $projectDir/templates/boxplotstats-template.sql --sql-output-file boxplotstats.sql
     duckdb < boxplotstats.sql
     """
 }

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -16,7 +16,7 @@ process compute_stats {
     python $projectDir/statistics/conv_ratio.py --blast-output $blast_parquet --fasta $fasta_file --output conv_ratio.json
 
     # compute boxplot stats and evalue.tab
-    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
     python $projectDir/statistics/render_boxplotstats_sql_template.py --blast-output $blast_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --boxplot-stats-output boxplot_stats.parquet --evalue-output evalue.tab --sql-template $projectDir/templates/boxplotstats-template.sql --sql-output-file boxplotstats.sql
     duckdb < boxplotstats.sql
     """

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -16,7 +16,8 @@ process compute_stats {
     python $projectDir/statistics/conv_ratio.py --blast-output $blast_parquet --fasta $fasta_file --output conv_ratio.json
 
     # compute boxplot stats and evalue.tab
-    python $projectDir/statistics/render_boxplotstats_sql_template.py --blast-output $blast_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --boxplot-stats-output boxplot_stats.parquet --evalue-output evalue.tab --sql-template $projectDir/templates/boxplotstats-template.sql --sql-output-file boxplotstats.sql
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    python $projectDir/statistics/render_boxplotstats_sql_template.py --blast-output $blast_parquet --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --boxplot-stats-output boxplot_stats.parquet --evalue-output evalue.tab --sql-template $projectDir/templates/boxplotstats-template.sql --sql-output-file boxplotstats.sql
     duckdb < boxplotstats.sql
     """
 }

--- a/pipelines/est/templates/restore-template.sql
+++ b/pipelines/est/templates/restore-template.sql
@@ -1,0 +1,8 @@
+SET memory_limit = '$mem_limit';
+SET temp_directory = '$duckdb_temp_dir';
+SET threads TO 1;
+
+COPY (
+    SELECT *
+    FROM read_parquet('$blast_parquet')
+) TO 'condensed.out' (FORMAT CSV, DELIMITER '\t', HEADER false);

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -20,7 +20,7 @@ process filter_blast {
     output:
         path "2.out"
     """
-    python $projectDir/filter/render_filter_blast_sql_template.py --blast-output $blast_parquet --filter-parameter ${params.filter_parameter} --filter-min-val ${params.filter_min_val} --min-length ${params.min_length} --max-length ${params.max_length} --sql-template $projectDir/templates/filterblast-template.sql --output-file 2.out --sql-output-file filterblast.sql
+    python $projectDir/filter/render_filter_blast_sql_template.py --blast-output $blast_parquet --filter-parameter ${params.filter_parameter} --filter-min-val ${params.filter_min_val} --min-length ${params.min_length} --max-length ${params.max_length} --sql-template $projectDir/templates/filterblast-template.sql --output-file 2.out --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --sql-output-file filterblast.sql
     duckdb < filterblast.sql
     """
 }

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -20,7 +20,8 @@ process filter_blast {
     output:
         path "2.out"
     """
-    python $projectDir/filter/render_filter_blast_sql_template.py --blast-output $blast_parquet --filter-parameter ${params.filter_parameter} --filter-min-val ${params.filter_min_val} --min-length ${params.min_length} --max-length ${params.max_length} --sql-template $projectDir/templates/filterblast-template.sql --output-file 2.out --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file filterblast.sql
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    python $projectDir/filter/render_filter_blast_sql_template.py --blast-output $blast_parquet --filter-parameter ${params.filter_parameter} --filter-min-val ${params.filter_min_val} --min-length ${params.min_length} --max-length ${params.max_length} --sql-template $projectDir/templates/filterblast-template.sql --output-file 2.out --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file filterblast.sql
     duckdb < filterblast.sql
     """
 }

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -20,7 +20,7 @@ process filter_blast {
     output:
         path "2.out"
     """
-    python $projectDir/filter/render_filter_blast_sql_template.py --blast-output $blast_parquet --filter-parameter ${params.filter_parameter} --filter-min-val ${params.filter_min_val} --min-length ${params.min_length} --max-length ${params.max_length} --sql-template $projectDir/templates/filterblast-template.sql --output-file 2.out --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir ${params.duckdb_temp_dir}-${task.index} --sql-output-file filterblast.sql
+    python $projectDir/filter/render_filter_blast_sql_template.py --blast-output $blast_parquet --filter-parameter ${params.filter_parameter} --filter-min-val ${params.filter_min_val} --min-length ${params.min_length} --max-length ${params.max_length} --sql-template $projectDir/templates/filterblast-template.sql --output-file 2.out --duckdb-memory-limit ${params.duckdb_memory_limit} --sql-output-file filterblast.sql
     duckdb < filterblast.sql
     """
 }

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -20,7 +20,7 @@ process filter_blast {
     output:
         path "2.out"
     """
-    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-"\$(date +%s)
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
     python $projectDir/filter/render_filter_blast_sql_template.py --blast-output $blast_parquet --filter-parameter ${params.filter_parameter} --filter-min-val ${params.filter_min_val} --min-length ${params.min_length} --max-length ${params.max_length} --sql-template $projectDir/templates/filterblast-template.sql --output-file 2.out --duckdb-memory-limit ${params.duckdb_memory_limit} --duckdb-temp-dir \${DUCKDB_TEMP} --sql-output-file filterblast.sql
     duckdb < filterblast.sql
     """


### PR DESCRIPTION
- [x] Changed `task.hash` to `task.index` to avoid the `exec`-block only hash string, which evaluates to null within a process block. `task.index` uses the process block's index in the workflow (AFAIK) and so should be unique for the given job. But, if multiple jobs are running on the same compute node, this may cause an issue.
- [x] The `generatessn.nf` code has a call to duckdb and an associated template file that accepts memory limit and temp directory definitions. I've implemented those input arguments to the rendering python script so that they are controlled by the implementation specific parameters rather than left up to default values set by duckdb.