### PR TITLE
287 support domain sequences in length histogram computation

### DIFF
--- a/pipelines/est/subworkflows/import.nf
+++ b/pipelines/est/subworkflows/import.nf
@@ -26,9 +26,17 @@ process cat_fasta_files {
         """
         $cat_cmd
         perl $projectDir/import/append_blast_query.pl --blast-query-file ${params.input_file} --output-sequence-file all_sequences.fasta
+
+        # Stop Nextflow here if the file is empty (i.e. no sequences were found)
+        [ -s all_sequences.fasta ] || { echo "ERROR: No sequences found after retrieval and merge."; exit 1; }
         """
     } else {
-        cat_cmd
+        """
+        $cat_cmd
+
+        # Stop Nextflow here if the file is empty (i.e. no sequences were found)
+        [ -s all_sequences.fasta ] || { echo "ERROR: No sequences found after retrieval and merge."; exit 1; }
+        """
     }
 }
 

--- a/pipelines/est/subworkflows/import.nf
+++ b/pipelines/est/subworkflows/import.nf
@@ -82,7 +82,7 @@ workflow IMPORT_AND_FILTER {
         // from the BLAST sequence database.  If the import mode is FASTA, then these IDs are only
         // ones that come from adding a family to the job
         accession_shards = split_sequence_ids(sequence_id_files.retrieval_ids, params.num_accession_shards)
-        fasta_files = get_sequences(accession_shards.flatten(), params.fasta_db)
+        raw_fasta_files = get_sequences(accession_shards.flatten(), params.fasta_db)
 
         // If importing FASTA file, reformat the FASTA file and create the file that will be added to
         // the dataset for all-by-all BLAST
@@ -90,10 +90,16 @@ workflow IMPORT_AND_FILTER {
             // sequence metadata is used to ensure that any sequences that were filtered out in a
             // prior step are also removed when rewriting the user fasta
             import_fasta_file = import_fasta(sequence_id_files.sequence_metadata, source_data.seq_mapping)
-            fasta_files = fasta_files.concat(import_fasta_file)
+            fasta_files = raw_fasta_files.concat(import_fasta_file)
+        } else {
+            fasta_files = raw_fasta_files
         }
 
-        fasta_file = cat_fasta_files(fasta_files.collect())
+        all_fasta_files = fasta_files.collect()
+        fasta_file = cat_fasta_files(
+            all_fasta_files
+                .ifEmpty { error "No FASTA sequences were retrieved. Terminating pipeline." }
+        )
 
     emit:
         accession_table = sequence_id_files.accession_table

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -1,5 +1,4 @@
 
-include { get_length_histogram } from "../../shared/nextflow/sequence.nf"
 include { merge_stats } from "../../shared/nextflow/util.nf"
 
 process compute_stats {
@@ -52,6 +51,22 @@ process visualize_boxplot_stats {
         --length-json-filename alignment_length.json \
         --pident-json-filename percent_identity.json \
         --edge-hist-json-filename number_of_edges.json
+    """
+}
+
+process get_length_histogram {
+    input:
+        path fasta_file
+        path accession_table
+        val seq_version
+    output:
+        path("*.histogram.txt"), emit: histograms
+    """
+    python $projectDir/../shared/python/compute_length_histogram.py \
+        --fasta-file ${fasta_file} \
+        --accession-table ${accession_table} \
+        --seq-type ${seq_version} \
+        --output-file ${seq_version}.histogram.txt
     """
 }
 

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -1,4 +1,5 @@
 
+include { get_length_histogram } from "../../shared/nextflow/sequence.nf"
 include { merge_stats } from "../../shared/nextflow/util.nf"
 
 process compute_stats {
@@ -54,22 +55,6 @@ process visualize_boxplot_stats {
     """
 }
 
-process get_length_histogram {
-    input:
-        path fasta_file
-        path accession_table
-        val seq_version
-    output:
-        path("${seq_version}.histogram.txt"), emit: histograms
-    """
-    python $projectDir/../shared/python/compute_length_histogram.py \
-        --fasta-file ${fasta_file} \
-        --accession-table ${accession_table} \
-        --seq-type ${seq_version} \
-        --output-file ${seq_version}.histogram.txt
-    """
-}
-
 process visualize_length_histograms {
     publishDir params.final_output_dir, mode: 'copy'
     input:
@@ -117,7 +102,7 @@ workflow REPORTING {
         histo_viz = visualize_length_histograms(length_histograms)
 
         files_to_merge_stream = import_stats.mix(stats.stats)
-        files_to_merge_stream.collect().set { files_to_merge }
+        files_to_merge = files_to_merge_stream.collect()
         final_stats = merge_stats(files_to_merge)
 
     emit:

--- a/pipelines/est/subworkflows/reporting.nf
+++ b/pipelines/est/subworkflows/reporting.nf
@@ -60,7 +60,7 @@ process get_length_histogram {
         path accession_table
         val seq_version
     output:
-        path("*.histogram.txt"), emit: histograms
+        path("${seq_version}.histogram.txt"), emit: histograms
     """
     python $projectDir/../shared/python/compute_length_histogram.py \
         --fasta-file ${fasta_file} \

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -128,3 +128,19 @@ process get_sequences {
     """
 }
 
+process get_length_histogram {
+    input:
+        path fasta_file
+        path accession_table
+        val seq_version
+    output:
+        path("${seq_version}.histogram.txt"), emit: histograms
+    """
+    python $projectDir/../shared/python/compute_length_histogram.py \
+        --fasta-file ${fasta_file} \
+        --accession-table ${accession_table} \
+        --seq-type ${seq_version} \
+        --output-file ${seq_version}.histogram.txt
+    """
+}
+

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -128,19 +128,3 @@ process get_sequences {
     """
 }
 
-process get_length_histogram {
-    input:
-        path fasta_file
-        path accession_table
-        val seq_version
-    output:
-        path("*.histogram.txt"), emit: histograms
-    """
-    python $projectDir/../shared/python/compute_length_histogram.py \
-        --fasta-file ${fasta_file} \
-        --accession-table ${accession_table} \
-        --seq-type ${seq_version} \
-        --output-file ${seq_version}.histogram.txt
-    """
-}
-

--- a/pipelines/shared/python/compute_length_histogram.py
+++ b/pipelines/shared/python/compute_length_histogram.py
@@ -1,37 +1,10 @@
 
 import argparse
+from Bio.SeqIO.FastaIO import SimpleFastaParser
 from collections import Counter
+import re
 import sys
 from typing import Iterator, Tuple, TextIO, Set, List
-
-def parse_fasta(file_handle: TextIO) -> Iterator[Tuple[str, str]]:
-    """
-    A simple FASTA parser that yields tuples of (header, sequence).
-
-    Parameters
-    ----------
-        file_handle
-            TextIO file object
-
-    Returns
-    -------
-        Iterator that returns one sequence at a time
-    """
-    header = None
-    sequence = []
-    for line in file_handle:
-        line = line.strip()
-        if not line:
-            continue
-        if line.startswith('>'):
-            if header:
-                yield (header, ''.join(sequence))
-            header = line[1:].split()[0] # Get the ID before any spaces
-            sequence = []
-        else:
-            sequence.append(line)
-    if header:
-        yield (header, ''.join(sequence))
 
 def parse_file(input_file: str, target_col: int, has_header_line: bool = True) -> Set[str]:
     """
@@ -111,17 +84,20 @@ def compute_sequence_lengths(fasta_file: str, valid_ids: Set[str] = None) -> Lis
     sequence_lengths = []
     try:
         with open(fasta_file, 'r') as fh:
-            for header, sequence in parse_fasta(fh):
+            for title, sequence in SimpleFastaParser(fh):
+                id_chunk = re.split(r'[ :]', title)[0]
+                parsed_id = id_chunk.split('|')[1] if '|' in id_chunk else id_chunk
+
                 include_sequence = False
 
                 # Include the sequence if it starts with 'ZZ' (e.g. the input to the EST pipeline
                 # was a FASTA file that didn't have UniProt IDs in the header) or 'ZINPUT' (the
                 # EST pipeline was based of a BLAST input).
-                if header.startswith('ZZ') or header.startswith('ZINPUT'):
+                if parsed_id.startswith(('ZZ', 'ZINPUT')):
                     include_sequence = True
                 
                 # Include if the ID is in our set of valid IDs.
-                elif valid_ids == None or header in valid_ids:
+                elif valid_ids == None or parsed_id in valid_ids:
                     include_sequence = True
 
                 if include_sequence:

--- a/tests/modules/01k_est_family_domain.sh
+++ b/tests/modules/01k_est_family_domain.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 
 rm -rf $OUTPUT_DIR
 
-family="IPR050967"
+family=$(<$EFI_TEST_FAMILY_ID)
 
 ./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --domain --domain-region domain
 bash $OUTPUT_DIR/run_nextflow.sh


### PR DESCRIPTION
This PR updates the length histogram computation logic to support domain sequences.

* Modified the sequence length extraction scripts to correctly handle and count domain-specific sequence lengths
* Stop pipeline early in workflow if no sequences were found
* Improved naming of variables

Closes #287
