### PR TITLE
309 make user taxonomy filter json format consistent

### DIFF
--- a/docs/source/lib/EFI/Import/Filter/Taxonomy.pm.rst
+++ b/docs/source/lib/EFI/Import/Filter/Taxonomy.pm.rst
@@ -26,8 +26,8 @@ taxonomic classification.
 JSON FILE FORMAT
 ================
 
-The JSON file format is an array of filter objects. Each object can
-define a filter by name, which can be referenced later.
+The predefined JSON file format is an array of filter objects. Each
+object can define a filter by name, which can be referenced later.
 
 ::
 
@@ -43,6 +43,22 @@ define a filter by name, which can be referenced later.
            "conditions": [ ... ]
        }
    ]
+
+The user-defined JSON file format is a single filter object:
+
+::
+
+   {
+       "name": "user_defined",
+       "operator": "AND" | "OR",
+       "conditions": [
+           {
+               "field":"domain",
+               "operator":"=",
+               "value":"Bacteria"
+           }, ...
+       ]
+   }
 
 
 
@@ -82,7 +98,6 @@ rule.
    The value to match against the specified field.
 
 **negate** (string, optional)
-   ----------------------------------------------------------------------------------------------------
    If present and set to ``"true"``, the condition is negated. This
    effectively changes the operator from equality to inequality (e.g.,
    ``"="`` becomes ``"!="``) or from ``"LIKE"`` to ``"NOT LIKE"``.
@@ -147,7 +162,6 @@ A filter that represents Eukaryota but excludes fungi:
 
 ::
 
-   [
        {
        "name": "eukaroyta_no_fungi",
        "operator": "AND",
@@ -184,21 +198,18 @@ A filter that represents Eukaryota but excludes fungi:
            }
        ]
    }
-   ]
 
 A user-defined filter that includes Bacteria only:
 
 ::
 
-   [
-       {
-           "name": "bacteria",
-           "operator": "OR",
-           "conditions": [
-               {
-                   "field": "domain",
-                   "value": "Bacteria"
-               }
-           ]
-       }
-   ]
+   {
+       "name": "bacteria",
+       "operator": "OR",
+       "conditions": [
+           {
+               "field": "domain",
+               "value": "Bacteria"
+           }
+       ]
+   }

--- a/lib/EFI/Import/Filter/Taxonomy.pm
+++ b/lib/EFI/Import/Filter/Taxonomy.pm
@@ -66,9 +66,9 @@ sub parseFilter {
     my $filterString = $self->readFile($filterFile);
 
     my $json = decode_json($filterString);
-    die "Invalid JSON filter string" if not $json or not $json->[0];
+    die "Invalid JSON filter string" if not $json or not ref $json eq "HASH";
 
-    my $whereClause = $self->parseFilterJson($json->[0]);
+    my $whereClause = $self->parseFilterJson($json);
 
     return $whereClause;
 }
@@ -140,7 +140,8 @@ taxonomic classification.
 
 =head1 JSON FILE FORMAT
 
-The JSON file format is an array of filter objects. Each object can define a filter by name, which can be referenced later.
+The predefined JSON file format is an array of filter objects. Each object can define a filter by
+name, which can be referenced later.
 
     [
         {
@@ -154,6 +155,20 @@ The JSON file format is an array of filter objects. Each object can define a fil
             "conditions": [ ... ]
         }
     ]
+
+The user-defined JSON file format is a single filter object:
+
+    {
+        "name": "user_defined",
+        "operator": "AND" | "OR",
+        "conditions": [
+            {
+                "field":"domain",
+                "operator":"=",
+                "value":"Bacteria"
+            }, ...
+        ]
+    }
 
 =head2 Top-Level Filter Object
 
@@ -258,59 +273,55 @@ SQL equivalent: C<< phylum NOT LIKE 'Ascomycota' >>
 
 A filter that represents Eukaryota but excludes fungi:
 
-	[
-	    {
-            "name": "eukaroyta_no_fungi",
-            "operator": "AND",
-            "conditions": [
-                {
-                    "field": "domain",
-                    "value": "Eukaryota"
-                },
-                {
-                    "field": "phylum",
-                    "value": "Ascomycota",
-                    "operator": "NOT"
-                },
-                {
-                    "field": "phylum",
-                    "value": "Basidiomycota",
-                    "operator": "NOT"
-                },
-                {
-                    "field": "phylum",
-                    "value": "Fungi incertae sedis",
-                    "operator": "NOT"
-                },
-                {
-                    "field": "phylum",
-                    "value": "unclassified Fungi",
-                    "operator": "NOT"
-                },
-                {
-                    "field": "species",
-                    "value": "%metagenome%",
-                    "operator": "NOT",
-                    "exact": false
-                }
-            ]
-        }
-	]
+	{
+        "name": "eukaroyta_no_fungi",
+        "operator": "AND",
+        "conditions": [
+            {
+                "field": "domain",
+                "value": "Eukaryota"
+            },
+            {
+                "field": "phylum",
+                "value": "Ascomycota",
+                "operator": "NOT"
+            },
+            {
+                "field": "phylum",
+                "value": "Basidiomycota",
+                "operator": "NOT"
+            },
+            {
+                "field": "phylum",
+                "value": "Fungi incertae sedis",
+                "operator": "NOT"
+            },
+            {
+                "field": "phylum",
+                "value": "unclassified Fungi",
+                "operator": "NOT"
+            },
+            {
+                "field": "species",
+                "value": "%metagenome%",
+                "operator": "NOT",
+                "exact": false
+            }
+        ]
+    }
 
 A user-defined filter that includes Bacteria only:
 
-    [
-        {
-            "name": "bacteria",
-            "operator": "OR",
-            "conditions": [
-                {
-                    "field": "domain",
-                    "value": "Bacteria"
-                }
-            ]
-        }
-    ]
+    {
+        "name": "bacteria",
+        "operator": "OR",
+        "conditions": [
+            {
+                "field": "domain",
+                "value": "Bacteria"
+            }
+        ]
+    }
 
 
 =cut

--- a/pipelines/est/subworkflows/import.nf
+++ b/pipelines/est/subworkflows/import.nf
@@ -1,5 +1,5 @@
 
-include { filter_ids; get_sequences; get_source_ids } from "../../shared/nextflow/sequence.nf"
+include { filter_ids; get_sequences; get_source_ids; get_user_filter_file } from "../../shared/nextflow/sequence.nf"
 
 process get_sunburst_data {
     publishDir params.final_output_dir, mode: 'copy'
@@ -64,8 +64,10 @@ workflow IMPORT_AND_FILTER {
         // We get sequence IDs and basic metadata from the input source, including those in FASTA files
         source_data = get_source_ids()
 
+        user_filter_file = get_user_filter_file()
+
         // Filter on all sequence IDs including UniRef, and including IDs in FASTA files
-        sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]))
+        sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]), user_filter_file)
 
         // Get sunburst data for all sequence IDs, after filtering
         get_sunburst_data(sequence_id_files.accession_table, sequence_id_files.sequence_metadata)

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -134,7 +134,7 @@ workflow {
         : Channel.value([])
 
     // Filter sequences out by length or other criteria (e.g. fragment, taxonomy)
-    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, Channel.value(null))
+    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, Channel.value([]))
 
     // Get annotations
     ssn_meta_file = get_annotations(final_ids.sequence_metadata)

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -134,7 +134,7 @@ workflow {
         : Channel.value([])
 
     // Filter sequences out by length or other criteria (e.g. fragment, taxonomy)
-    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file)
+    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, Channel.value(null))
 
     // Get annotations
     ssn_meta_file = get_annotations(final_ids.sequence_metadata)

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -9,7 +9,7 @@ def formatFilterArgs(filter_list) {
 
 def get_user_filter_file() {
     def user_filter_entry = params.filter?.find { it.startsWith("user-filter=") }
-    def user_filter_file = user_filter_entry ? file(user_filter_entry.split('=')[1]) : null
+    def user_filter_file = user_filter_entry ? file(user_filter_entry.split('=')[1]) : Channel.value([])
     return user_filter_file
 }
 

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -3,7 +3,14 @@ def formatFilterArgs(filter_list) {
     if (!filter_list || filter_list.isEmpty()) {
         return ""
     }
-    return "--filter " + filter_list.join(" --filter ")
+    def filter_args_list = filter_list.findAll { !it.startsWith("user-filter=") }
+    return !filter_args_list.isEmpty() ? "--filter " + filter_args_list.join(" --filter ") : ""
+}
+
+def get_user_filter_file() {
+    def user_filter_entry = params.filter?.find { it.startsWith("user-filter=") }
+    def user_filter_file = user_filter_entry ? file(user_filter_entry.split('=')[1]) : null
+    return user_filter_file
 }
 
 process filter_ids {
@@ -13,6 +20,8 @@ process filter_ids {
         path source_meta        // sequence metdata
         path source_stats       // statistics of source import process
         path explicit_ids_file  // manually specify which IDs pass through; this may be empty (e.g. Channel.value([]))
+        path user_filter_file   // path to user taxonomy filter file; this may be empty (e.g. Channel.value([]));
+                                //     this is necessary to stage the filter file so it can be read inside this process
     output:
         path 'accession_table.tab', emit: 'accession_table'     // table of all sequence IDs, including UniRef IDs, filtered
         path 'sequence_metadata.tab', emit: 'sequence_metadata' // sequence metdata in metadata format
@@ -21,6 +30,7 @@ process filter_ids {
     script:
     def xids_file = explicit_ids_file ? "--filter explicit-ids-file=${explicit_ids_file}" : ""
     def filter_args = formatFilterArgs(params.filter)
+    def user_filter_arg = user_filter_file ? "--filter user-filter=${user_filter_file}" : ""
     """
     perl $projectDir/../shared/import/filter_ids.pl \
         --efi-config ${params.efi_config} \
@@ -33,7 +43,7 @@ process filter_ids {
         --sequence-meta-file sequence_metadata.tab \
         --retrieval-ids-file retrieval_ids.tab \
         --stats-file import_stats.json \
-        ${filter_args} \
+        ${filter_args} ${user_filter_arg} \
         ${xids_file}
     """
 }

--- a/pipelines/taxonomy/taxonomy.nf
+++ b/pipelines/taxonomy/taxonomy.nf
@@ -1,5 +1,5 @@
 
-include { filter_ids; get_source_ids } from "../shared/nextflow/sequence.nf"
+include { filter_ids; get_source_ids; get_user_filter_file } from "../shared/nextflow/sequence.nf"
 
 process get_sunburst_data {
     publishDir params.final_output_dir, mode: 'copy'
@@ -39,9 +39,11 @@ workflow {
     // We get sequence IDs and basic metadata from the input source, including those in FASTA files
     source_data = get_source_ids()
 
+    user_filter_file = get_user_filter_file()
+
     // Filter on all sequence IDs including UniRef, and including IDs in FASTA files.
     // The last parameter is empty (used only for generatessn)
-    sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]))
+    sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]), user_filter_file)
 
     // Get sunburst data for all sequence IDs, after filtering
     sunburst_data = get_sunburst_data(sequence_id_files.accession_table, sequence_id_files.sequence_metadata)

--- a/tests/modules/extended/01d_est_family_filter_taxonomy_user.sh
+++ b/tests/modules/extended/01d_est_family_filter_taxonomy_user.sh
@@ -15,18 +15,16 @@ family=$(<$EFI_TEST_FAMILY_ID)
 user_filter="$TEST_RESULTS_DIR/${self}_user_filter.json"
 
 cat <<JSON > $user_filter
-[
-    {
-        "name": "bacteria",
-        "operator": "OR",
-        "conditions": [
-            {
-                "field": "domain",
-                "value": "Bacteria"
-            }
-        ]
-    }
-]
+{
+    "name": "bacteria",
+    "operator": "OR",
+    "conditions": [
+        {
+            "field": "domain",
+            "value": "Bacteria"
+        }
+    ]
+}
 JSON
 
 ./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --filter user-file=$user_filter

--- a/tests/modules/extended/01d_est_family_filter_taxonomy_user.sh
+++ b/tests/modules/extended/01d_est_family_filter_taxonomy_user.sh
@@ -12,22 +12,22 @@ mkdir $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-user_filter="$TEST_RESULTS_DIR/${self}_user_filter.json"
+user_filter=$(realpath "$TEST_RESULTS_DIR/${self}_user_filter.json")
 
 cat <<JSON > $user_filter
 {
-    "name": "bacteria",
+    "name": "archae",
     "operator": "OR",
     "conditions": [
         {
             "field": "domain",
-            "value": "Bacteria"
+            "value": "Archaea"
         }
     ]
 }
 JSON
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --filter user-file=$user_filter
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --filter user-filter=$user_filter
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --threshold-min-val 87 --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME


### PR DESCRIPTION
This PR standardizes the JSON format used for the user taxonomy filter across the EST toolset. Previously, there were inconsistencies in how taxonomy data was structured between the frontend input and the backend processing scripts, which could lead to issues during job submission or pipeline execution.

* Updated the JSON schema for taxonomy filters to ensure a consistent structure across front and back ends
* Updated filter_ids process to accept taxonomy filter file (necessary for proper staging)
