### PR TITLE
319 optimize xgmml generation code

### DIFF
--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -24,6 +24,7 @@ params {
     threshold_metric = "alignment_score"
     min_length = 0
     max_length = 65000
+    max_ssn_edges = 200000000
 
     // GNT/GND parameters
     nb_size = 20

--- a/lib/EFI/GNT/GND/Util.pm
+++ b/lib/EFI/GNT/GND/Util.pm
@@ -13,7 +13,7 @@ use EFI::Util::Colors;
 
 sub new {
     my $class = shift;
-    my %args;
+    my %args = @_;
 
     my $self = {};
     bless $self, $class;

--- a/lib/EFI/SSN/XgmmlWriter.pm
+++ b/lib/EFI/SSN/XgmmlWriter.pm
@@ -44,7 +44,7 @@ sub write {
     my $sequences = shift;
     my $connectivity = shift;
     my $title = shift;
-    my $edges = shift;
+    my $edgeGenerator = shift;
 
     $self->{sequences} = $sequences;
     $self->{metadata} = $metadata;
@@ -65,7 +65,7 @@ sub write {
 
     $self->writeNodes(\@ids, $attrs);
 
-    $self->writeEdges($edges);
+    $self->writeEdges($edgeGenerator);
 
     $self->writeClosing();
 
@@ -185,13 +185,14 @@ sub writeNode {
 # Writes the edges to the file.
 #
 # Parameters:
-#    $edges - array ref of edge data
+#    $edgeGenerator - generator returning edge data every time it is called
 #
 sub writeEdges {
     my $self = shift;
-    my $edges = shift;
+    my $edgeGenerator = shift;
 
-    foreach my $edge (@$edges) {
+    # Read edges from the file line-by-line
+    while (my $edge = $edgeGenerator->()) {
         $self->writeEdge($edge);
         $self->{stats}->{num_edges}++;
     }

--- a/pipelines/generatessn/create/create_full_ssn.pl
+++ b/pipelines/generatessn/create/create_full_ssn.pl
@@ -168,8 +168,10 @@ sub validateInputBlast {
     # Grab first line of file
     open my $fh, "<", $inputBlast or die "Unable to read input BLAST file '$inputBlast': $!";
     my $line = "";
-    while (not ($line = <$fh>)) {};
+    while (not ($line = <$fh>) and not eof($fh)) {};
     close $fh;
+
+    return (VALID, undef, 0) if not $line;
 
     my ($sid, $qid, @p) = split(m/\t/, $line);
     my $seqType = get_sequence_type($sid);

--- a/pipelines/generatessn/create/create_full_ssn.pl
+++ b/pipelines/generatessn/create/create_full_ssn.pl
@@ -1,12 +1,8 @@
-#!/usr/bin/env perl
 
 use strict;
 use warnings;
 
 use FindBin;
-use Getopt::Long;
-use JSON;
-use List::MoreUtils qw{uniq};
 
 use lib "$FindBin::Bin/../../../lib";
 

--- a/pipelines/generatessn/create/create_full_ssn.pl
+++ b/pipelines/generatessn/create/create_full_ssn.pl
@@ -14,7 +14,7 @@ use EFI::SSN::XgmmlWriter;
 use EFI::Util::FASTA qw(read_fasta_file);
 use EFI::Util::FileStats qw(save_stats);
 
-use constant DEFAULT_MAX_EDGES => 10000000;
+use constant DEFAULT_MAX_EDGES => 200000000;
 use constant VALID => 1;
 
 

--- a/pipelines/generatessn/create/create_full_ssn.pl
+++ b/pipelines/generatessn/create/create_full_ssn.pl
@@ -11,7 +11,6 @@ use List::MoreUtils qw{uniq};
 use lib "$FindBin::Bin/../../../lib";
 
 use EFI::Annotations::Fields qw(:annotations);
-use EFI::EST::AlignmentScore qw(compute_ascore);
 use EFI::Options;
 use EFI::Sequence::Collection;
 use EFI::Sequence::Type qw(get_sequence_type);
@@ -48,10 +47,10 @@ my $sequences = read_fasta_file($opts->{fasta});
 
 my $connectivity = loadConnectivity($opts->{nc_map});
 
-my $edges = loadEdges($opts->{blast});
+my $edgeGenerator = loadEdges($opts->{blast});
 
 my $writer = new EFI::SSN::XgmmlWriter(output_file => $opts->{output}, use_min_edge_attr => $opts->{use_min_edge_attr}, db_version => $dbVersion, seq_type => $seqType);
-$writer->write($inputIds, $sequences, $connectivity, $title, $edges);
+$writer->write($inputIds, $sequences, $connectivity, $title, $edgeGenerator);
 
 
 my $stats = { file_stats => $writer->getStats() };
@@ -76,13 +75,15 @@ save_stats($opts->{stats}, $stats) if $opts->{stats};
 #
 # loadEdges
 #
-# Loads the SSN edges by reading the BLAST results file and computing the alignment score.
+# Creates a generator function that returns edge data every time it is called.
 #
 # Parameters:
 #    $inputBlast - path to input BLAST file from all-by-all
 #
 # Returns:
-#    array ref of edges, with each edge being a hash ref of edge data
+#    A "generator" function that yields edge data every time it is called.  The data returned
+#    by the iterator contains a hash ref of edge data (source, target, pid, ascore, alen).  The
+#    return value is undef when the end of the file is reached
 #
 # Notes:
 #
@@ -92,26 +93,24 @@ save_stats($opts->{stats}, $stats) if $opts->{stats};
 sub loadEdges {
     my $inputBlast = shift;
 
-    # Write edges to the SSN
     open my $bfh, "<", $inputBlast or die "Could not open BLAST file '$inputBlast': $!";
 
-    my @edges;
+    return sub {
+        my $line = <$bfh>;
+        return if not $line;
 
-    while (my $line = <$bfh>) {
         chomp $line;
 
-        my @parts = split /\t/, $line;
-        #   0     1     2     3      4          5      6
-        my ($qid, $sid, $pid, $alen, $bitscore, $qlen, $slen) = @parts;
+        my ($qid, $sid, $pid, $alen, $bitscore, $qlen, $slen, $alignmentScore) = split(/\t/, $line);
 
-        my $alignmentScore = compute_ascore(@parts);
-
-        push @edges, { source => $qid, target => $sid, pid => $pid, ascore => $alignmentScore, alen => $alen };
+        return {
+            source => $qid,
+            target => $sid,
+            pid => $pid,
+            ascore => $alignmentScore,
+            alen => $alen,
+        };
     }
-
-    close $bfh;
-
-    return \@edges;
 }
 
 

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -16,6 +16,7 @@ process import_data {
         path '_accession_table.tab', emit: source_ids
         path '_sequence_metadata.tab', emit: seq_meta_file
         path 'empty_stats.json', emit: stats                // This serves as an empty placeholder; required as a starting point for filter_ids
+    script:
     """
     cp $existing_blast_output _1.out.parquet
     cp $existing_fasta_file _sequences.fa
@@ -30,6 +31,7 @@ process threshold_blast {
         path blast_parquet
     output:
         path "2.out"
+    script:
     """
     DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
     python $projectDir/threshold/render_threshold_blast_sql_template.py \
@@ -110,6 +112,7 @@ process create_full_ssn {
         --metadata ${ssn_meta_file} \
         --output ssn.xgmml \
         --title "${final_job_name}" \
+        --max-edges ${params.max_ssn_edges} \
         --db-version ${params.db_version} \
         --stats stats.json
     cp ssn.xgmml "${file_name}"

--- a/pipelines/generatessn/templates/thresholdblast-template.sql
+++ b/pipelines/generatessn/templates/thresholdblast-template.sql
@@ -4,7 +4,7 @@ SET threads TO 1;
 SET preserve_insertion_order = false;
 
 COPY (
-    SELECT qseqid, sseqid, pident, alignment_length, bitscore, query_length, subject_length
+    SELECT qseqid, sseqid, pident, alignment_length, bitscore, query_length, subject_length, alignment_score
     FROM read_parquet('$blast_output')
     WHERE $threshold_metric >= $threshold_min_val AND
           query_length >= $min_length AND


### PR DESCRIPTION
Three separate issues were addressed:

* When writing SSNs with high alignment scores, no edges were produced.  Due to a logic bug, this created an infinite loop.  This was fixed by checking for end of file from within the while loop in question.
* GNDs with large numbers of sequences were not able to be written by the tool due to a missing parameter.  Smaller datasets were processed successfully because the code in question was used to optimize writing of large datasets.
* Writing large SSNs caused jobs to crash because of excessive memory usage.  This was caused by loading all edges into memory from the blast results file (`2.out`) and then passing it to the EFI::SSN::XgmmlWriter class as a data structure.  This problem is solved by passing a "generator" to the EFI::SSN::XgmmlWriter class that read lines one at a time from the file, avoiding loading the entire file into memory.