### PR TITLE
321 - Add blast evalues for GNT Retrieve Diagram BLAST jobs

### DIFF
--- a/lib/EFI/GNT/GND.pm
+++ b/lib/EFI/GNT/GND.pm
@@ -125,7 +125,7 @@ sub initializeDatabase {
 #        default IDs are ordered as they exist in the input
 #    $unirefSizeMapping - hash ref that maps ID to UniRef sizes; only UniRef IDs will be present,
 #        see EFI::GNT::GND::Uniref::computeUnirefSizeMapping() for format
-#    $blastEValues - has ref that maps ID to blast E-Values; only filled if the GND is associated
+#    $blastEValues - hash ref that maps ID to blast E-Values; only filled if the GND is associated
 #        with GND Retrieve Diagram job with import_mode BLAST.
 #
 # Returns:
@@ -167,8 +167,6 @@ sub insertClusterData {
         $queryData{uniref50_size} = $unirefSizeMapping->{$queryData{id}}->{uniref50} // 0;
         $queryData{&COLOR_COLUMN} = $self->{util}->getColorForPfam($queryData{pfam}, assign_query_gene_color => 1);
         $queryData{cluster_num} = $clusterNum;
-
-	# NOTE
         $queryData{evalue} = $blastEValues->{$queryData{id}} if exists $blastEValues->{$queryData{id}};
 
         return \%queryData;

--- a/lib/EFI/GNT/GND.pm
+++ b/lib/EFI/GNT/GND.pm
@@ -70,6 +70,10 @@ sub save {
         $self->{uniref}->insertUnirefMapping($clusterData, $networkType, $uniref50IdMapping, $uniref90IdMapping, $idIndexMap, $idClusterMap);
     }
 
+    if ($args{blast_evalues}) {
+	    # handle blast evalues being added to the GND table...
+    }
+
     $self->{dbh}->commit();
 
     my $numIds = scalar keys %$idIndexMap;

--- a/lib/EFI/GNT/GND.pm
+++ b/lib/EFI/GNT/GND.pm
@@ -42,6 +42,8 @@ sub save {
     my $matchedIds = $args{matched_ids} // {};
     my $unmatchedIds = $args{unmatched_ids} // [];
 
+    my $blastEValues = $args{blast_evalues} // {};
+
     if (not $self->initializeDatabase($gndFile, $networkType)) {
         return 0;
     }
@@ -58,7 +60,7 @@ sub save {
 
     my $sortSeqIds = $args{sort_sequence_ids} // 0;
 
-    my ($families, $clusterIndex, $idIndexMap, $idClusterMap) = $self->insertClusterData($clusterData, $clusterNames, $sortSeqIds, $unirefSizeMapping);
+    my ($families, $clusterIndex, $idIndexMap, $idClusterMap) = $self->insertClusterData($clusterData, $clusterNames, $sortSeqIds, $unirefSizeMapping, $blastEValues);
     $self->insertMetadata($metadata);
     $self->insertFamilies($families);
     $self->insertClusterIndex($clusterIndex);
@@ -68,10 +70,6 @@ sub save {
 
     if ($networkType ne SEQ_UNIPROT and $uniref50IdMapping and $uniref90IdMapping) {
         $self->{uniref}->insertUnirefMapping($clusterData, $networkType, $uniref50IdMapping, $uniref90IdMapping, $idIndexMap, $idClusterMap);
-    }
-
-    if ($args{blast_evalues}) {
-	    # handle blast evalues being added to the GND table...
     }
 
     $self->{dbh}->commit();
@@ -127,6 +125,8 @@ sub initializeDatabase {
 #        default IDs are ordered as they exist in the input
 #    $unirefSizeMapping - hash ref that maps ID to UniRef sizes; only UniRef IDs will be present,
 #        see EFI::GNT::GND::Uniref::computeUnirefSizeMapping() for format
+#    $blastEValues - has ref that maps ID to blast E-Values; only filled if the GND is associated
+#        with GND Retrieve Diagram job with import_mode BLAST.
 #
 # Returns:
 #    $families - array ref of list of all Pfam and InterPro families that were in the input,
@@ -142,6 +142,7 @@ sub insertClusterData {
     my $clusterNames = shift;
     my $sortSequenceIds = shift;
     my $unirefSizeMapping = shift // {};
+    my $blastEValues = shift // {};
 
     my $families = {};
     # A unique, sequential number for each query ID
@@ -166,6 +167,10 @@ sub insertClusterData {
         $queryData{uniref50_size} = $unirefSizeMapping->{$queryData{id}}->{uniref50} // 0;
         $queryData{&COLOR_COLUMN} = $self->{util}->getColorForPfam($queryData{pfam}, assign_query_gene_color => 1);
         $queryData{cluster_num} = $clusterNum;
+
+	# NOTE
+        $queryData{evalue} = $blastEValues->{$queryData{id}} if exists $blastEValues->{$queryData{id}};
+
         return \%queryData;
     };
 

--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -69,6 +69,12 @@ if ($opts->{sequence_version} ne SEQ_UNIPROT) {
     $args{metanode_mapping} = $uniprotMapping;
 }
 
+# Read the blast_hits.tab file to get the array of blast_evalues to the query sequence
+if (defined $opts->{blast_evalues}) {
+    my blastEvalues = parse_blast_hits($opts->{blast_evalues})
+    $args{blast_evalues} = $blastEvalues
+}
+
 my $numIdsSaved = $gnd->save($opts->{gnd}, $gnn, $metadata, %args);
 if (not $numIdsSaved) {
     die "Unable to save GND to '$opts->{gnd}'";
@@ -96,6 +102,7 @@ sub validateAndProcessOptions {
     $optParser->addOption("source-type=s", 0, "the source of the data provided, e.g. BLAST, FASTA, ID list");
     $optParser->addOption("source-sequence-file=s", 0, "path to a file containing the sequence used to generate the results, only valid for BLAST sources");
     $optParser->addOption("stats=s", 0, "path to file to output GND statistics to");
+    $optParser->addOption("blast-evalues=s", 0, "path to file containing e-values for the BLAST alignment results for gathered sequence");
 
     if (not $optParser->parseOptions() or $optParser->wantHelp()) {
         print $optParser->printHelp();

--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -138,14 +138,14 @@ sub parseBlastHits {
     while (my $line = <$fh>) {
         chomp $line;
         
-        # skip empty lines
+        # Skip empty lines
         next if $line =~ /^\s*$/;
         
-        # expected line formats:
+        # Expected line formats:
         # tr|A0A7C7D6A2|A0A7C7D6A2_9FIRM    9e-148 # returns {"A0A7C7D6A2": "9e-148"} 
         # A0A0U1KYM0                        8e-147 # returns {"A0A0U1KYM0": "8e-147"}
 
-        # split line by tab-separated columns
+        # Split line by tab-separated columns
         my ($col1, $evalue) = split /\t/, $line;
         my $id = ($col1 =~ /^[^|]+\|([^|]+)\|/) ? $1 : $col1;
 

--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -70,9 +70,9 @@ if ($opts->{sequence_version} ne SEQ_UNIPROT) {
 }
 
 # Read the blast_hits.tab file to get the array of blast_evalues to the query sequence
-if (defined $opts->{blast_evalues}) {
-    my blastEvalues = parse_blast_hits($opts->{blast_evalues})
-    $args{blast_evalues} = $blastEvalues
+if ($opts->{blast_evalues} and -f $opts->{blast_evalues}) {
+    my $blastEvalues = parseBlastHits($opts->{blast_evalues});
+    $args{blast_evalues} = $blastEvalues;
 }
 
 my $numIdsSaved = $gnd->save($opts->{gnd}, $gnn, $metadata, %args);
@@ -102,7 +102,7 @@ sub validateAndProcessOptions {
     $optParser->addOption("source-type=s", 0, "the source of the data provided, e.g. BLAST, FASTA, ID list");
     $optParser->addOption("source-sequence-file=s", 0, "path to a file containing the sequence used to generate the results, only valid for BLAST sources");
     $optParser->addOption("stats=s", 0, "path to file to output GND statistics to");
-    $optParser->addOption("blast-evalues=s", 0, "path to file containing e-values for the BLAST alignment results for gathered sequence");
+    $optParser->addOption("blast-evalues=s", 0, "path to file containing e-values for the BLAST alignment results for gathered sequence", OPT_FILE);
 
     if (not $optParser->parseOptions() or $optParser->wantHelp()) {
         print $optParser->printHelp();
@@ -125,5 +125,34 @@ sub validateAndProcessOptions {
     }
 
     return $opts;
+}
+
+
+
+
+sub parseBlastHits {
+    my $blastHitsTab = shift;
+    my %results;
+    
+    open my $fh, "<" $blastHitsTab or die "Unable to open tabulated blast alignments file '$blastHitsTab': $!";
+    while (my $line = <$fh>) {
+        chomp $line;
+        
+        # skip empty lines
+        next if $line =~ /^\s*$/;
+        
+        # expected line formats:
+        # tr|A0A7C7D6A2|A0A7C7D6A2_9FIRM    9e-148 # returns {"A0A7C7D6A2": "9e-148"} 
+        # A0A0U1KYM0                        8e-147 # returns {"A0A0U1KYM0": "8e-147"}
+
+        # split line by tab-separated columns
+        my ($col1, $evalue) = split /\t/, $line;
+        my $id = ($col1 =~ /^[^|]+\|([^|]+)\|/) ? $1 : $col1;
+
+        $results{$id} = $evalue;
+   }
+
+   close $fh;
+   return \%results;
 }
 

--- a/pipelines/gnd/create_gnd.pl
+++ b/pipelines/gnd/create_gnd.pl
@@ -54,7 +54,7 @@ my $matchedIds = {};
 my $unmatchedIds = [];
 my $metadata = {
     neighborhood_size => $opts->{nb_size},
-    title => $opts->{title} // "",
+    name => $opts->{title} // "",
     type => $opts->{source_type} // "",
     sequence => $opts->{source_sequence} // "",
 };
@@ -134,7 +134,7 @@ sub parseBlastHits {
     my $blastHitsTab = shift;
     my %results;
     
-    open my $fh, "<" $blastHitsTab or die "Unable to open tabulated blast alignments file '$blastHitsTab': $!";
+    open my $fh, "<", $blastHitsTab or die "Unable to open tabulated blast alignments file '$blastHitsTab': $!";
     while (my $line = <$fh>) {
         chomp $line;
         

--- a/pipelines/gnd/gnd.nf
+++ b/pipelines/gnd/gnd.nf
@@ -3,12 +3,14 @@ process create_gnd {
     publishDir params.final_output_dir, mode: 'copy'
     input:
         path id_list 
+        path blast_evalue_file
     output:
         path "gnd.sqlite", emit: "gnd_db"
         path "gnd.sqlite.zip", emit: "zipped_gnd_db"
         path "stats.json", emit: "stats"
 
     script:
+    def blastHitsArgs = params.import_mode == "blast" ? "--blast-evalues ${blast_evalue_file}" : ""
     """
     perl ${projectDir}/create_gnd.pl \
         --efi-config "${params.efi_config}" \
@@ -17,7 +19,8 @@ process create_gnd {
         --cluster-map ${id_list} \
         --nb-size ${params.nb_size} \
         --gnd gnd.sqlite \
-        --stats stats.json
+        --stats stats.json \
+        ${blastHitsArgs}
     zip gnd.sqlite.zip gnd.sqlite
     """
 }
@@ -26,7 +29,8 @@ process run_blast {
     input:
         path sequence_file
     output:
-        path "init_blast.out"
+        path "init_blast.out", emit: "raw_blast_out"
+        path "blast_hits.tab", emit: "e_values"
 
     script:
     """
@@ -37,7 +41,10 @@ process run_blast {
         -e ${params.import_blast_evalue} \
         -m 8 \
         -o init_blast.out
-    if [[ ! -s init_blast.out ]]; then
+
+    if [[ -s init_blast.out ]]; then
+        awk '! /^#/ {print \$2"\t"\$11}' init_blast.out | sort -k2nr > blast_hits.tab
+    else
         echo "BLAST did not return any matches.  Verify that the sequence is a protein and not a nucleotide sequence." | tee /dev/stderr
         exit 1
     fi
@@ -129,7 +136,7 @@ workflow {
         parse_data = parse_accession_for_ids(input_file_ch,)
     } else if (params.import_mode == "blast") {
         blast_results = run_blast(input_file_ch)
-        parse_data = parse_blast_results_for_ids(input_file_ch, blast_results)
+        parse_data = parse_blast_results_for_ids(input_file_ch, blast_results.raw_blast_out)
     } else if (params.import_mode == "fasta") {
         parse_data = parse_fasta_for_ids(input_file_ch)
     } else {

--- a/pipelines/gnd/gnd.nf
+++ b/pipelines/gnd/gnd.nf
@@ -11,6 +11,10 @@ process create_gnd {
 
     script:
     def blastHitsArgs = params.import_mode == "blast" ? "--blast-evalues ${blast_evalue_file}" : ""
+    
+    // If there was no job name specified, then assign a default
+    def final_job_name = params.job_name ?: "Sequence Source: ${params.sequence_version}, nNeighbors: ${params.nb_size}"
+
     """
     perl ${projectDir}/create_gnd.pl \
         --efi-config "${params.efi_config}" \
@@ -20,6 +24,7 @@ process create_gnd {
         --nb-size ${params.nb_size} \
         --gnd gnd.sqlite \
         --stats stats.json \
+        --title "${final_job_name}" \
         ${blastHitsArgs}
     zip gnd.sqlite.zip gnd.sqlite
     """
@@ -134,14 +139,15 @@ workflow {
 
     if (params.import_mode == "accessions") {
         parse_data = parse_accession_for_ids(input_file_ch)
-        extra_metadata_file = Channel.empty()
+        extra_metadata_file = Channel.value([])
     } else if (params.import_mode == "blast") {
         blast_results = run_blast(input_file_ch)
         parse_data = parse_blast_results_for_ids(input_file_ch, blast_results.raw_blast_out)
         extra_metadata_file = blast_results.e_values
     } else if (params.import_mode == "fasta") {
         parse_data = parse_fasta_for_ids(input_file_ch)
-        extra_metadata_file = Channel.empty()
+        extra_metadata_file = Channel.value([])
+        //extra_metadata_file = Channel.empty()
     } else {
         error "Mode '${params.import_mode}' is invalid"
     }

--- a/pipelines/gnd/gnd.nf
+++ b/pipelines/gnd/gnd.nf
@@ -13,7 +13,7 @@ process create_gnd {
     def blastHitsArgs = params.import_mode == "blast" ? "--blast-evalues ${blast_evalue_file}" : ""
     
     // If there was no job name specified, then assign a default
-    def final_job_name = params.job_name ?: "Sequence Source: ${params.sequence_version}, nNeighbors: ${params.nb_size}"
+    def final_job_name = params.job_name ?: "${params.import_mode}, Sequence Source: ${params.sequence_version}, nNeighbors: ${params.nb_size}"
 
     """
     perl ${projectDir}/create_gnd.pl \

--- a/pipelines/gnd/gnd.nf
+++ b/pipelines/gnd/gnd.nf
@@ -133,18 +133,21 @@ workflow {
     def input_file_ch = Channel.fromPath(params.input_file)
 
     if (params.import_mode == "accessions") {
-        parse_data = parse_accession_for_ids(input_file_ch,)
+        parse_data = parse_accession_for_ids(input_file_ch)
+        extra_metadata_file = Channel.empty()
     } else if (params.import_mode == "blast") {
         blast_results = run_blast(input_file_ch)
         parse_data = parse_blast_results_for_ids(input_file_ch, blast_results.raw_blast_out)
+        extra_metadata_file = blast_results.e_values
     } else if (params.import_mode == "fasta") {
         parse_data = parse_fasta_for_ids(input_file_ch)
+        extra_metadata_file = Channel.empty()
     } else {
         error "Mode '${params.import_mode}' is invalid"
     }
 
     id_list = convert_to_id_list(parse_data.source_ids, parse_data.source_meta)
 
-    gnd = create_gnd(id_list)
+    gnd = create_gnd(id_list, extra_metadata_file)
 }
 


### PR DESCRIPTION
- [x] Read the `blast_hits.tab` file to gather e-values to the query sequence and add those values to the associated rows in the gnd.sqlite database table.
- [x] Fix minor disagreement between "title" and "name" metadata names preventing the GND from being given a name. Update the default naming to be at least a little informative of what the GND represents.

One note, this hasn't been thoroughly tested for `blast_hits.tab` files that don't follow the line formatting of `tr|{UniProtID}|{longUniProtID}\t{evalue}\n`. I'm not even sure other line formats are possible, since this only is relevant for BLAST import mode of one query sequence against the library of sequences. Won't all lines follow that format? Idk, either way, I implemented some regex logic to handle lines that break from that format. Its just somewhat untested. 

closes #321 and closes #322