### PR TITLE
327 remove self alignments after restore condensed

### DIFF
--- a/pipelines/convergenceratio/convergenceratio.nf
+++ b/pipelines/convergenceratio/convergenceratio.nf
@@ -152,7 +152,7 @@ workflow {
     // Compute the convergence ratio based on the BLAST results
     //stats_files = compute_blast_conv_ratio(blast_parquet.combine(fasta_lengths_parquet, by: 0))
     //stats_files = compute_blast_conv_ratio(reduced_blast_parquet.combine(fasta_lengths_parquet, by: 0))
-    stats_files = compute_blast_conv_ratio(reduced_blast_parquet.join(fasta_lengths_parquet))
+    stats_files = compute_blast_conv_ratio(blast_parquet.join(fasta_lengths_parquet))
 
     // Merge the data for all the clusters into one file
     merge_conv_ratios(stats_files.collect(), cr_table)

--- a/pipelines/convergenceratio/convergenceratio.nf
+++ b/pipelines/convergenceratio/convergenceratio.nf
@@ -151,7 +151,6 @@ workflow {
 
     // Compute the convergence ratio based on the BLAST results
     //stats_files = compute_blast_conv_ratio(blast_parquet.combine(fasta_lengths_parquet, by: 0))
-    //stats_files = compute_blast_conv_ratio(reduced_blast_parquet.combine(fasta_lengths_parquet, by: 0))
     stats_files = compute_blast_conv_ratio(blast_parquet.join(fasta_lengths_parquet))
 
     // Merge the data for all the clusters into one file

--- a/pipelines/est/subworkflows/all_by_all.nf
+++ b/pipelines/est/subworkflows/all_by_all.nf
@@ -6,8 +6,10 @@ workflow ALL_BY_ALL {
         original_fasta
 
     main:
-        // Cluster redundant sequences for BLAST computation (formerly known as multiplex)
-        if (params.multiplex) {
+        // Cluster redundant sequences for BLAST computation (formerly known as multiplex).
+        // Only performed when input sequences are from Uniprot, since sequence sets from
+        // UniRef90 and UniRef50 are already sequence-unique.
+        if (params.multiplex && params.sequence_version == "uniprot") {
             condensed_files = condense_redundant(original_fasta)
             blast_input_fasta = condensed_files.fasta_file
             condensed = condensed_files.condensed

--- a/pipelines/est/subworkflows/all_by_all.nf
+++ b/pipelines/est/subworkflows/all_by_all.nf
@@ -30,11 +30,11 @@ workflow ALL_BY_ALL {
         blast_input = blastdb.combine(fasta_shards.transpose(), by: 0)
         blast_fractions = all_by_all_blast( blast_input ).groupTuple()
 
-        // Eliminate duplicate and self-edges
+        // Eliminate duplicates
         reduced_blast_parquet = blastreduce(blast_fractions.join(fasta_lengths_parquet))
 
         // Expand redundant sequences after BLAST computation (formerly known as demultiplex)
-        if (params.multiplex) {
+        if (params.multiplex && params.sequence_version == "uniprot") {
             reduced_blast_parquet = restore_condensed(reduced_blast_parquet.join(condensed))
         }
 

--- a/pipelines/shared/condense/restore_condensed_sequences.py
+++ b/pipelines/shared/condense/restore_condensed_sequences.py
@@ -1,5 +1,6 @@
 
 import argparse
+import os
 import re
 
 import duckdb
@@ -22,11 +23,13 @@ def get_args() -> argparse.ArgumentParser:
     parser.add_argument(
         "--cd-hit-cluster",
         type=str,
+        required=True,
         help="Path to the CD-HIT cluster file"
     )
     parser.add_argument(
         "--condensed-blast",
         type=str,
+        required=True,
         help="Path to the condensed BLAST result parquet"
     )
     parser.add_argument(
@@ -64,7 +67,7 @@ def get_args() -> argparse.ArgumentParser:
 
 def connect_duckdb(
         memory_limit: str,
-        temp_dir: str | Path,
+        temp_dir: str,
         n_threads: int
     ) -> duckdb.DuckDBPyConnection:
     """
@@ -189,7 +192,7 @@ def restore_blast_results(
     # Expand all blast results using the cluster mapping using Cartesian
     # product of the sequence id set. Remove duplicates and self-alignments 
     # here. Equivalent to filling in and reporting only the top triangle of the
-    # 2d matrix.
+    # 2d matrix, ignoring the diagonal.
     temp_out = os.path.join(args.duckdb_temp_dir, f"restored.parquet")
     # Prepare the query to do the uncondensing work.
     query = f"""
@@ -205,6 +208,19 @@ def restore_blast_results(
 
         JOIN cluster_mapping AS smap ON aln.sseqid = smap.rep_id
 
+        /* 
+        
+        /* 
+           This query removes self-alignments, duplicate edges, and 
+           intra-cluster alignments too (wrong to do so)
+        */ 
+        WHERE aln.qseqid != aln.sseqid
+          AND qmap.seq_id < smap.seq_id
+        */
+
+        /* 
+           This query removes self-alignments and duplicate edges.
+        */ 
         WHERE qmap.seq_id < smap.seq_id
 
     ) TO '{output_file_path}' (FORMAT 'parquet');

--- a/pipelines/shared/condense/restore_condensed_sequences.py
+++ b/pipelines/shared/condense/restore_condensed_sequences.py
@@ -204,8 +204,10 @@ def restore_blast_results(
     # here. Equivalent to filling in and reporting only the top triangle of the
     # 2d matrix, ignoring the diagonal.
     temp_out = os.path.join(args.duckdb_temp_dir, f"restored.parquet")
-    # Prepare the query to do the uncondensing work.
 
+    # Prepare the query to do the uncondensing work.
+    # Query strings generated using Chat-GPT:
+    # https://chatgpt.com/share/6a106cef-be94-83ea-bba5-47e396f53c5d
     if old_method_bool:
         CONDITION = """
         /*

--- a/pipelines/shared/condense/restore_condensed_sequences.py
+++ b/pipelines/shared/condense/restore_condensed_sequences.py
@@ -1,105 +1,244 @@
-import sys
+
 import argparse
 import re
 
-def parse_cdhit_clstr(clstr_path):
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def get_args() -> argparse.ArgumentParser:
     """
-    Parses a CD-HIT .clstr file to map representative IDs to their list of children.
-    Returns a dictionary: {representative_id: [child_id_1, child_id_2, ...]}
+    Optain the command line arguments.
+
+    Returns
+    -------
+        argparse Namespace containing the input parameters and output file path
     """
-    clusters = {}
+    parser = argparse.ArgumentParser(
+        description="Restore condensed BLAST results to the full sequence set."
+    )
+    # file io arguments
+    parser.add_argument(
+        "--cd-hit-cluster",
+        type=str,
+        help="Path to the CD-HIT cluster file"
+    )
+    parser.add_argument(
+        "--condensed-blast",
+        type=str,
+        help="Path to the condensed BLAST result parquet"
+    )
+    parser.add_argument(
+        "--output-file",
+        type=str,
+        default="1.out.parquet",
+        help="Output file path where the restored sequence set's BLAST results are written. Will be parquet."
+    )
+    # duckdb arguments
+    parser.add_argument(
+        "--duckdb-memory-limit",
+        type=str,
+        default="4GB",
+        help="Soft limit on DuckDB memory usage"
+    )
+    parser.add_argument(
+        "--duckdb-threads",
+        type=int,
+        default=1,
+        help="Number of threads to use"
+    )
+    parser.add_argument(
+        "--duckdb-compression",
+        type=str,
+        default="zstd",
+        help="Type of compression to use in temporary files"
+    )
+    parser.add_argument(
+        "--duckdb-temp-dir",
+        type=str,
+        default="./duckdb",
+        help="Location DuckDB should use for temporary files"
+    )
+    return parser.parse_args()
+
+def connect_duckdb(
+        memory_limit: str,
+        temp_dir: str | Path,
+        n_threads: int
+    ) -> duckdb.DuckDBPyConnection:
+    """
+    Create a connection to a duckdb instance. Configure the connection to use
+    the set amount of RAM, use a local temp storage directory if duckdb
+    processing runs out of RAM, and use the set number of threads.
+
+    Parameters
+    ----------
+        memory_limit
+            str, format: XGB where X is the maximum integer value of memory
+            allotable to duckdb (units of GB).
+        temp_dir
+            str, global path to a storage space where duckdb can write temp
+            database file(s) if it goes beyond the memory limit set.
+        n_threads
+            int, number of threads available for duckdb to use.
+
+    Returns
+    -------
+        connection to duckdb database in memory
+    """
+
+    # Initialize DuckDB connection with strict limits
+    conn = duckdb.connect(database=':memory:')
+    conn.execute(f"SET memory_limit='{memory_limit}';")
+    conn.execute(f"SET temp_directory='{temp_dir}';")
+    conn.execute(f"SET threads={n_threads};")
+    #conn.execute(f"SET max_temp_directory_size = '100GB';")
+
+    return conn
+
+def close_duckdb(conn: duckdb.DuckDBPyConnection):
+    """
+    Close the connection to the duckdb instance.
+    """
+    conn.close()
+
+def process_cd_hit_clusters(clstr_file: str, output_path: str):
+    """
+    Read the CD-HIT cluster file and stash the map between sequence ID and
+    associated representative sequence ID in a temporary parquet file.
+
+    Parameters
+    ----------
+        clstr_file
+            str, path to the CD-HIT cluster file. Expected format detailed in
+            https://www.bioinformatics.org/cd-hit/cd-hit-user-guide.
+
+        output_path
+            str, path to the temporary storage space where the map.parquet
+            file will be written.
+
+    Creates the map file in f"{output_path}/map.parquet"
+    """
+    cluster_mapping = {"seq_id":[], "rep_id": []}
     current_rep = None
-    buffer_children = []
-    
+
     # Regex to extract ID between '>' and '...'
     # Example: 0	200aa, >SeqID... *
     id_pattern = re.compile(r">(.*?)\.\.\.")
 
-    with open(clstr_path, 'r') as f:
+    with open(clstr_file, "r") as f:
         for line in f:
             line = line.strip()
+            # ">Cluster ###" lines indicate a new rep seq and associated
+            # degenerate sequences.
             if line.startswith(">Cluster"):
-                # If we have a previous cluster buffered, assign it to its rep
-                if current_rep and buffer_children:
-                    clusters[current_rep] = buffer_children
-                
-                # Reset for new cluster
                 current_rep = None
-                buffer_children = []
             else:
-                # Parse sequence line
-                match = id_pattern.search(line)
-                if match:
-                    seq_id = match.group(1)
-                    buffer_children.append(seq_id)
-                    # Check if this is the representative (ends with *)
-                    if line.endswith('*'):
+                # match the regex pattern for the seq_id
+                matched_id = id_pattern.search(line)
+                if matched_id:
+                    seq_id = matched_id.group(1)
+                    # rep seq lines end with "*"
+                    if line.endswith("*"):
                         current_rep = seq_id
 
-        # Catch the last cluster
-        if current_rep and buffer_children:
-            clusters[current_rep] = buffer_children
-            
-    return clusters
+                    cluster_mapping["seq_id"].append(seq_id)
+                    if current_rep:
+                        cluster_mapping["rep_id"].append(current_rep)
+                    else:
+                        print(line)
+                        cluster_mapping["rep_id"].append(seq_id)
 
-def expand_edges(blastin_path, blastout_path, clusters):
+    table = pa.Table.from_pydict(cluster_mapping)
+    pq.write_table(table, f"{output_path}/map.parquet")
+    return f"{output_path}/map.parquet"
+
+def restore_blast_results(
+        conn: duckdb.DuckDBPyConnection,
+        cluster_parquet: str,
+        condensed_blast: str,
+        output_file_path: str
+    ):
     """
-    Reads BLAST file, looks up children for query/subject, and restores edges.
+    Read the reduced but still condensed BLAST results parquet file then
+    uncondense those results based on the CD-HIT cluster mapping parquet. Use
+    condensed self-alignment results to fill in missing BLAST results. Finally,
+    remove self-alignments and output the final blast parquet file.
+
+    Parameters
+    ----------
+        conn
+            duckdb.DuckDBPyConnection, a in-memory duckdb sql connection.
+        cluster_parquet
+            str, path to the map.parquet file created in previous step.
+        condensed_blast
+            str, path to the input condensed BLAST results parquet file.
+        output_file_path
+            str, path where the final parquet file will be written.
+
+    Creates the reduced, uncondensed BLAST results parquet file, saved as
+    f"{output_file_path}".
     """
-    with open(blastin_path, 'r') as fin, open(blastout_path, 'w') as fout:
-        for line in fin:
-            parts = line.strip().split()
-            if not parts: 
-                continue
-                
-            query_rep = parts[0]
-            subject_rep = parts[1]
-            # Keep the rest of the BLAST columns (pident, evalue, etc.)
-            rest_of_line = parts[2:] 
+    # Read in the cluster parquet file that contains the mapping of uncondensed
+    # seqids to their condensed rep seq id.
+    conn.execute(
+        f"CREATE TABLE cluster_mapping AS SELECT * FROM read_parquet('{cluster_parquet}');"
+    )
 
-            # Validation
-            if query_rep not in clusters:
-                print(f"SOURCE {query_rep} does not exist in the cluster file", file=sys.stderr)
-                continue
-            
-            query_children = clusters[query_rep]
-            
-            # CASE A: Self-Hit (Cluster hits itself)
-            # This creates the internal clique (e.g. A-B, A-C, B-C) but excludes self-loops (A-A).
-            if query_rep == subject_rep:
-                n = len(query_children)
-                for i in range(n):
-                    for j in range(i + 1, n):
-                        child_q = query_children[i]
-                        child_s = query_children[j]
-                        # Join and write
-                        out_line = "\t".join([child_q, child_s] + rest_of_line)
-                        fout.write(out_line + "\n")
+    # Expand all blast results using the cluster mapping using Cartesian
+    # product of the sequence id set. Remove duplicates and self-alignments 
+    # here. Equivalent to filling in and reporting only the top triangle of the
+    # 2d matrix.
+    temp_out = os.path.join(args.duckdb_temp_dir, f"restored.parquet")
+    # Prepare the query to do the uncondensing work.
+    query = f"""
+    COPY (
+        SELECT
+            qmap.seq_id AS qseqid,
+            smap.seq_id AS sseqid,
+            aln.* EXCLUDE (qseqid, sseqid)
 
-            # CASE B: Cross-Hit (Cluster A hits Cluster B)
-            else:
-                if subject_rep not in clusters:
-                    print(f"TARGET {subject_rep} does not exist in the cluster file", file=sys.stderr)
-                    continue
+        FROM read_parquet('{condensed_blast}') AS aln
 
-                subject_children = clusters[subject_rep]
-                
-                for child_q in query_children:
-                    for child_s in subject_children:
-                        out_line = "\t".join([child_q, child_s] + rest_of_line)
-                        fout.write(out_line + "\n")
+        JOIN cluster_mapping AS qmap ON aln.qseqid = qmap.rep_id
+
+        JOIN cluster_mapping AS smap ON aln.sseqid = smap.rep_id
+
+        WHERE qmap.seq_id < smap.seq_id
+
+    ) TO '{output_file_path}' (FORMAT 'parquet');
+    """
+    conn.execute(query)
+    print("Done restoring the condensed blast results file to its full glory.")
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Restore condensed BLAST results based on CD-HIT clusters.")
-    parser.add_argument("--cd-hit-cluster", required=True, help="CD-HIT .clstr file")
-    parser.add_argument("--condensed-blast", required=True, help="Input BLAST file with results using condensed sequences")
-    parser.add_argument("--restored-blast", required=True, help="Output BLAST file with original sequences restored")
-    
-    args = parser.parse_args()
-    
-    print("Reading clusters...")
-    cluster_map = parse_cdhit_clstr(args.cd_hit_cluster)
-    
-    print("Expanding edges...")
-    expand_edges(args.condensed_blast, args.restored_blast, cluster_map)
-    print("Done.")
+    args = get_args()
+
+    os.makedirs(args.duckdb_temp_dir, exist_ok=True)
+
+    # process the CD-HIT cluster file
+    cluster_parquet = process_cd_hit_clusters(
+        args.cd_hit_cluster,
+        args.duckdb_temp_dir    # maybe should just be written in nf work dir "./"
+    )
+
+    # Connect to the duckdb in-memory database
+    conn = connect_duckdb(
+        memory_limit = args.duckdb_memory_limit,
+        temp_dir = args.duckdb_temp_dir,
+        n_threads = args.duckdb_threads
+    )
+
+    # process the condensed blast result file along with CD-HIT cluster database
+    restore_blast_results(
+        conn,
+        cluster_parquet,
+        args.condensed_blast,
+        args.output_file
+    )
+
+    close_duckdb(conn)
+
+

--- a/pipelines/shared/condense/restore_condensed_sequences.py
+++ b/pipelines/shared/condense/restore_condensed_sequences.py
@@ -63,6 +63,12 @@ def get_args() -> argparse.ArgumentParser:
         default="./duckdb",
         help="Location DuckDB should use for temporary files"
     )
+    parser.add_argument(
+        "--use-old-method",
+        type=bool,
+        default=False,
+        help="Past versions of did not include intra-cluster edges. Will be mirrored if set to True"
+    )
     return parser.parse_args()
 
 def connect_duckdb(
@@ -161,7 +167,8 @@ def restore_blast_results(
         conn: duckdb.DuckDBPyConnection,
         cluster_parquet: str,
         condensed_blast: str,
-        output_file_path: str
+        output_file_path: str,
+        old_method_bool: bool = False
     ):
     """
     Read the reduced but still condensed BLAST results parquet file then
@@ -179,6 +186,9 @@ def restore_blast_results(
             str, path to the input condensed BLAST results parquet file.
         output_file_path
             str, path where the final parquet file will be written.
+        old_method_bool
+            bool, if True, ignore intra-cluster alignment results equivalent
+            to ignoring edges between 100% identical sequences.
 
     Creates the reduced, uncondensed BLAST results parquet file, saved as
     f"{output_file_path}".
@@ -190,11 +200,28 @@ def restore_blast_results(
     )
 
     # Expand all blast results using the cluster mapping using Cartesian
-    # product of the sequence id set. Remove duplicates and self-alignments 
+    # product of the sequence id set. Remove duplicates and self-alignments
     # here. Equivalent to filling in and reporting only the top triangle of the
     # 2d matrix, ignoring the diagonal.
     temp_out = os.path.join(args.duckdb_temp_dir, f"restored.parquet")
     # Prepare the query to do the uncondensing work.
+
+    if old_method_bool:
+        CONDITION = """
+        /*
+           This query removes self-alignments, duplicate edges, and
+           intra-cluster alignments too (wrong to do so)
+        */
+        WHERE aln.qseqid != aln.sseqid AND qmap.seq_id < smap.seq_id
+        """
+    else:
+        CONDITION = """
+        /*
+           This query removes self-alignments and duplicate edges.
+        */
+        WHERE qmap.seq_id < smap.seq_id
+        """
+
     query = f"""
     COPY (
         SELECT
@@ -208,20 +235,7 @@ def restore_blast_results(
 
         JOIN cluster_mapping AS smap ON aln.sseqid = smap.rep_id
 
-        /* 
-        
-        /* 
-           This query removes self-alignments, duplicate edges, and 
-           intra-cluster alignments too (wrong to do so)
-        */ 
-        WHERE aln.qseqid != aln.sseqid
-          AND qmap.seq_id < smap.seq_id
-        */
-
-        /* 
-           This query removes self-alignments and duplicate edges.
-        */ 
-        WHERE qmap.seq_id < smap.seq_id
+        {CONDITION}
 
     ) TO '{output_file_path}' (FORMAT 'parquet');
     """

--- a/pipelines/shared/condense/restore_condensed_sequences.py
+++ b/pipelines/shared/condense/restore_condensed_sequences.py
@@ -66,7 +66,7 @@ def get_args() -> argparse.ArgumentParser:
     parser.add_argument(
         "--use-old-method",
         type=bool,
-        default=False,
+        default=True,
         help="Past versions of did not include intra-cluster edges. Will be mirrored if set to True"
     )
     return parser.parse_args()

--- a/pipelines/shared/condense/restore_condensed_sequences.py
+++ b/pipelines/shared/condense/restore_condensed_sequences.py
@@ -266,7 +266,8 @@ if __name__ == "__main__":
         conn,
         cluster_parquet,
         args.condensed_blast,
-        args.output_file
+        args.output_file,
+        args.use_old_method
     )
 
     close_duckdb(conn)

--- a/pipelines/shared/condense/restore_condensed_sequences_old.py
+++ b/pipelines/shared/condense/restore_condensed_sequences_old.py
@@ -1,0 +1,105 @@
+import sys
+import argparse
+import re
+
+def parse_cdhit_clstr(clstr_path):
+    """
+    Parses a CD-HIT .clstr file to map representative IDs to their list of children.
+    Returns a dictionary: {representative_id: [child_id_1, child_id_2, ...]}
+    """
+    clusters = {}
+    current_rep = None
+    buffer_children = []
+    
+    # Regex to extract ID between '>' and '...'
+    # Example: 0	200aa, >SeqID... *
+    id_pattern = re.compile(r">(.*?)\.\.\.")
+
+    with open(clstr_path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith(">Cluster"):
+                # If we have a previous cluster buffered, assign it to its rep
+                if current_rep and buffer_children:
+                    clusters[current_rep] = buffer_children
+                
+                # Reset for new cluster
+                current_rep = None
+                buffer_children = []
+            else:
+                # Parse sequence line
+                match = id_pattern.search(line)
+                if match:
+                    seq_id = match.group(1)
+                    buffer_children.append(seq_id)
+                    # Check if this is the representative (ends with *)
+                    if line.endswith('*'):
+                        current_rep = seq_id
+
+        # Catch the last cluster
+        if current_rep and buffer_children:
+            clusters[current_rep] = buffer_children
+            
+    return clusters
+
+def expand_edges(blastin_path, blastout_path, clusters):
+    """
+    Reads BLAST file, looks up children for query/subject, and restores edges.
+    """
+    with open(blastin_path, 'r') as fin, open(blastout_path, 'w') as fout:
+        for line in fin:
+            parts = line.strip().split()
+            if not parts: 
+                continue
+                
+            query_rep = parts[0]
+            subject_rep = parts[1]
+            # Keep the rest of the BLAST columns (pident, evalue, etc.)
+            rest_of_line = parts[2:] 
+
+            # Validation
+            if query_rep not in clusters:
+                print(f"SOURCE {query_rep} does not exist in the cluster file", file=sys.stderr)
+                continue
+            
+            query_children = clusters[query_rep]
+            
+            # CASE A: Self-Hit (Cluster hits itself)
+            # This creates the internal clique (e.g. A-B, A-C, B-C) but excludes self-loops (A-A).
+            if query_rep == subject_rep:
+                n = len(query_children)
+                for i in range(n):
+                    for j in range(i + 1, n):
+                        child_q = query_children[i]
+                        child_s = query_children[j]
+                        # Join and write
+                        out_line = "\t".join([child_q, child_s] + rest_of_line)
+                        fout.write(out_line + "\n")
+
+            # CASE B: Cross-Hit (Cluster A hits Cluster B)
+            else:
+                if subject_rep not in clusters:
+                    print(f"TARGET {subject_rep} does not exist in the cluster file", file=sys.stderr)
+                    continue
+
+                subject_children = clusters[subject_rep]
+                
+                for child_q in query_children:
+                    for child_s in subject_children:
+                        out_line = "\t".join([child_q, child_s] + rest_of_line)
+                        fout.write(out_line + "\n")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Restore condensed BLAST results based on CD-HIT clusters.")
+    parser.add_argument("--cd-hit-cluster", required=True, help="CD-HIT .clstr file")
+    parser.add_argument("--condensed-blast", required=True, help="Input BLAST file with results using condensed sequences")
+    parser.add_argument("--restored-blast", required=True, help="Output BLAST file with original sequences restored")
+    
+    args = parser.parse_args()
+    
+    print("Reading clusters...")
+    cluster_map = parse_cdhit_clstr(args.cd_hit_cluster)
+    
+    print("Expanding edges...")
+    expand_edges(args.condensed_blast, args.restored_blast, cluster_map)
+    print("Done.")

--- a/pipelines/shared/nextflow/blast.nf
+++ b/pipelines/shared/nextflow/blast.nf
@@ -35,7 +35,7 @@ process all_by_all_blast {
 }
 
 process blastreduce_old {
-    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex
+    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version == "uniprot"
 
     input:
         tuple val(fid), path(blast_files), path(fasta_length_parquet)
@@ -58,7 +58,7 @@ process blastreduce_old {
 }
 
 process blastreduce {
-    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex
+    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version == "uniprot"
 
     input:
         tuple val(fid), path(blast_files), path(fasta_length_parquet)

--- a/pipelines/shared/nextflow/blast.nf
+++ b/pipelines/shared/nextflow/blast.nf
@@ -35,7 +35,7 @@ process all_by_all_blast {
 }
 
 process blastreduce_old {
-    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version == "uniprot"
+    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version != "uniprot"
 
     input:
         tuple val(fid), path(blast_files), path(fasta_length_parquet)
@@ -58,7 +58,7 @@ process blastreduce_old {
 }
 
 process blastreduce {
-    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version == "uniprot"
+    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version != "uniprot"
 
     input:
         tuple val(fid), path(blast_files), path(fasta_length_parquet)
@@ -130,7 +130,7 @@ process create_blast_db {
 }
 
 // Formerly known as demultiplex
-process restore_condensed {
+process restore_condensed_old {
     publishDir params.final_output_dir, mode: 'copy', overwrite: true
 
     input:
@@ -157,6 +157,30 @@ process restore_condensed {
         --blast-output 1.out
     """
 }
+
+process restore_condensed {
+    publishDir params.final_output_dir, mode: 'copy', overwrite: true
+
+    input:
+        tuple val(fid), path(blast_parquet, stageAs: "reduced.parquet"), path(condensed)
+
+    output:
+        tuple val(fid), path("1.out.parquet")
+
+    script:
+    """
+    # python script
+    DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
+    python $projectDir/..shared/condensed/restore_condensed_sequences.py \
+        --cd-hit-cluster ${condensed} \
+        --condensed-blast reduced.parquet \
+        --output-file 1.out.parquet \
+        --duckdb-memory-limit ${params.duckdb_memory_limit} \
+        --duckdb-threads ${task.ncpus} \
+        --duckdb-temp-dir \${DUCKDB_TEMP}
+    """
+}
+
 
 process split_fasta {
     input:

--- a/pipelines/shared/nextflow/blast.nf
+++ b/pipelines/shared/nextflow/blast.nf
@@ -35,7 +35,7 @@ process all_by_all_blast {
 }
 
 process blastreduce_old {
-    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version != "uniprot"
+    publishDir params.final_output_dir, mode: 'copy', enabled: (!params.multiplex || params.sequence_version != "uniprot")
 
     input:
         tuple val(fid), path(blast_files), path(fasta_length_parquet)
@@ -58,7 +58,7 @@ process blastreduce_old {
 }
 
 process blastreduce {
-    publishDir params.final_output_dir, mode: 'copy', enabled: !params.multiplex && params.sequence_version != "uniprot"
+    publishDir params.final_output_dir, mode: 'copy', enabled: (!params.multiplex || params.sequence_version != "uniprot")
 
     input:
         tuple val(fid), path(blast_files), path(fasta_length_parquet)
@@ -149,7 +149,7 @@ process restore_condensed_old {
         --duckdb-temp-dir \${DUCKDB_TEMP} \
         --sql-output-file restore.sql
     duckdb < restore.sql
-    python $projectDir/../shared/condense/restore_condensed_sequences.py \
+    python $projectDir/../shared/condense/restore_condensed_sequences_old.py \
         --condensed-blast condensed.out \
         --restored-blast 1.out \
         --cd-hit-cluster ${condensed}
@@ -171,12 +171,12 @@ process restore_condensed {
     """
     # python script
     DUCKDB_TEMP="${params.duckdb_temp_dir}/duckdb-${task.index}-"\$(date +%s)
-    python $projectDir/..shared/condensed/restore_condensed_sequences.py \
+    python $projectDir/../shared/condense/restore_condensed_sequences.py \
         --cd-hit-cluster ${condensed} \
         --condensed-blast reduced.parquet \
         --output-file 1.out.parquet \
         --duckdb-memory-limit ${params.duckdb_memory_limit} \
-        --duckdb-threads ${task.ncpus} \
+        --duckdb-threads 1 \
         --duckdb-temp-dir \${DUCKDB_TEMP}
     """
 }

--- a/tests/modules/18b_conv_ratio_complete_graph.sh
+++ b/tests/modules/18b_conv_ratio_complete_graph.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [[ ! -e "$EFI_TEST_SSN_COMPLETE_GRAPH" ]]; then
+    echo "Test skipped; missing $EFI_TEST_SSN_COMPLETE_GRAPH"
+    exit 0
+fi
+
+TEST_RESULTS_DIR=$1
+CONFIG_FILE=$2
+
+self=$(basename "$0" .sh)
+OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
+
+rm -rf $OUTPUT_DIR
+
+./bin/create_conv_ratio_nextflow_params.py --output-dir $OUTPUT_DIR --ssn-input $EFI_TEST_SSN_COMPLETE_GRAPH --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --nextflow-config $CONFIG_FILE --ascore 5
+bash $OUTPUT_DIR/run_nextflow.sh
+

--- a/tests/modules/19e_cluster_analysis_complete_graph.sh
+++ b/tests/modules/19e_cluster_analysis_complete_graph.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+if [[ ! -e "$EFI_TEST_SSN_COMPLETE_GRAPH" ]]; then
+    echo "Test skipped; missing $EFI_TEST_SSN_COMPLETE_GRAPH"
+    exit 0
+fi
+
+TEST_RESULTS_DIR=$1
+CONFIG_FILE=$2
+
+self=$(basename "$0" .sh)
+OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
+
+rm -rf $OUTPUT_DIR
+
+./bin/create_clusteranalysis_nextflow_params.py --output-dir $OUTPUT_DIR --ssn-input $EFI_TEST_SSN_COMPLETE_GRAPH --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --nextflow-config $CONFIG_FILE \
+    --weblogo \
+    --hmms \
+    --length-histo \
+    --compute-cons-res \
+    --residues C,A \
+    --pid-thresholds 50,100
+bash $OUTPUT_DIR/run_nextflow.sh
+

--- a/tests/test_env.sh
+++ b/tests/test_env.sh
@@ -21,6 +21,7 @@ EFI_TEST_SSN_UNIPROT=
 EFI_TEST_SSN_UNIREF90=
 EFI_TEST_SSN_UNIREF50=
 EFI_TEST_SSN_REPNODE=
+EFI_TEST_SSN_COMPLETE_GRAPH=
 EFI_TEST_RESULTS_DIR=
 
 # loop over input arguments
@@ -156,6 +157,7 @@ export EFI_TEST_SSN_UNIPROT="$DATA_DIR/ssn.xgmml.zip"
 export EFI_TEST_SSN_UNIREF90="$DATA_DIR/ssn_uniref90.xgmml.zip"
 export EFI_TEST_SSN_UNIREF50="$DATA_DIR/ssn_uniref50.xgmml"
 export EFI_TEST_SSN_REPNODE="$DATA_DIR/ssn_repnode70.xgmml.zip"
+export EFI_TEST_SSN_COMPLETE_GRAPH="$DATA_DIR/complete_graph.xgmml"
 export EFI_TEST_ID_LIST_FILE="$DATA_DIR/gnd_id_list.txt"
 export EFI_TEST_RESULTS_DIR=$results_dir
 


### PR DESCRIPTION
This PR is a large rework of the `restore_condensed_sequences.py` script to use the duckdb python api instead of doing the work using raw python code. First the cd-hit cluster file is parsed into a parquet file. Then, the cluster parquet and the alignment parquet file are used in one query to expand the cluster alignment results to full sequence set. A final blast alignment file (default name: 1.out.parquet) is written that contains the expanded blast results without any "self-edges" or self-alignment results (which were present previously). 

The old process block and python code are kept, for now, just with slight name change.

The above change should solve the Convergence Ratio errors we've been seeing where there were N-too-many edges (where N is the number of sequences in the SSN cluster), arising from self-alignment results. This also implements a bug fix relative to the production site, where intra-CD-HIT-cluster alignment results are written when they previously were not. There is a CLI argument to switch functionality between old and new behavior for validation/testing purposes.

Additionally, the nextflow `publishDir` lines for "multiplex" calls now also confirm that the `params.sequence_version` is set to "uniprot" (which is set by default in `default_params.config`) before any CD-HIT condensing and uncondensing is done. UniRef sequence sets will never need the CD-HIT call to be performed, so that will save us some time.