### PR TITLE
337 fix statsjson for ssn utilties

### DIFF
--- a/lib/EFI/Import/Source/Accession.pm
+++ b/lib/EFI/Import/Source/Accession.pm
@@ -180,7 +180,6 @@ sub identifyAccessionIds {
         $destSeqData->addSequence($id, $attr);
     }
 
-    $self->addStatsValue("num_ids", scalar @ids);
     $self->addStatsValue("num_matched", $numUniprotIds);
     $self->addStatsValue("num_unmatched", $numNoMatches);
     $self->addStatsValue("num_foreign", $numForeign);

--- a/lib/EFI/Import/Source/FASTA.pm
+++ b/lib/EFI/Import/Source/FASTA.pm
@@ -202,7 +202,6 @@ sub parseFasta {
         }
     }
 
-    $self->addStatsValue("num_ids", $seqCount);
     $self->addStatsValue("num_headers", $headerCount);
     $self->addStatsValue("num_matched", $numMatched);
     $self->addStatsValue("num_unmatched", $seqCount - $numMatched);

--- a/lib/EFI/Import/Source/Family.pm
+++ b/lib/EFI/Import/Source/Family.pm
@@ -76,8 +76,8 @@ sub loadFromSource {
 
     my $numSharedSeq = $self->makeMetadata($ids, $destSeqData);
 
-    # Get the UniRef IDs that are in the input family(s)
-    my ($numUniref90Matched, $numUniref50Matched) = $self->getUnirefIds($uniprotUniref);
+    # Edit the structure to get the UniRef IDs that are in the input family(s)
+    $self->getUnirefIds($uniprotUniref);
 
     # Add the UniRef IDs to the metadata file
     $self->addUnirefIds($destSeqData, $self->{sequence_version}, $uniprotUniref);
@@ -85,10 +85,11 @@ sub loadFromSource {
     $self->addStatsValue("num_ids", $numIds);
     if ($self->{sequence_version} ne SEQ_UNIPROT) {
         $self->addStatsValue("num_full_family", $numFullFamily);
-        $self->addStatsValue("num_uniref90_in_family", $numUniref90Matched);
-        $self->addStatsValue("num_uniref50_in_family", $numUniref50Matched);
+        $self->addStatsValue("num_shared_uniref_ids", $numSharedSeq) if $numSharedSeq; # overlap between primary import source and family
+    } else {
+        $self->addStatsValue("num_family", $numFullFamily);
+        $self->addStatsValue("num_shared_ids", $numSharedSeq) if $numSharedSeq; # overlap between primary import source and family
     }
-    $self->addStatsValue("num_shared_ids", $numSharedSeq) if $numSharedSeq; # overlap between primary import source and family
 
     return $numIds;
 }
@@ -185,8 +186,9 @@ sub getFamilyNames {
 #     $queryData - hash ref pointing to list of query parameters
 #
 # Returns:
-#     hash ref of IDs mapping to family domain
-#     total number of IDs found
+#     hash ref of IDs mapping to family domain; if the input mode is UniRef, this will only
+#         contain the UniRef IDs, otherwise UniProt IDs
+#     total number of UniProt IDs found
 #     hash ref of mapping of UniProt to corresponding UniRef90 and UniRef50 IDs
 #
 sub executeQueries {
@@ -194,7 +196,6 @@ sub executeQueries {
     my $queryData = shift;
 
     my $ids = {};
-    my $numIds = 0;
     my $uniprotUniref = {};
     my $sequenceLengths = {};
 
@@ -214,8 +215,7 @@ sub executeQueries {
         }
 
         # Returns the number of UniProt or UniRef sequences
-        my $numUp = $self->processQuery($sth, $ids, $uniprotUniref, $sequenceLengths);
-        $numIds += $numUp;
+        $self->processQuery($sth, $ids, $uniprotUniref, $sequenceLengths);
     }
 
     # Alter the domains to fit the given region if the user specifies a domain region that is
@@ -223,6 +223,9 @@ sub executeQueries {
     if ($self->{domain}) {
         $ids = $self->{domain}->processDomains($ids, $sequenceLengths);
     }
+
+    # This hash ref contains the lengths of every unique UniProt sequence ID in the entire dataset
+    my $numIds = scalar keys %$sequenceLengths;
 
     return ($ids, $numIds, $uniprotUniref);
 }
@@ -275,17 +278,12 @@ sub makeSqlStatement {
 #     $uniprotUniref - hash ref, mapping UniProt ID to corresponding UniRef90 and UniRef50 IDs
 #     $sequenceLengths - hash ref, mapping UniProt ID to sequence length
 #
-# Returns:
-#     number of UniProt IDs in the query
-#
 sub processQuery {
     my $self = shift;
     my $sth = shift;
     my $ids = shift;
     my $uniprotUniref = shift;
     my $sequenceLengths = shift;
-
-    my $numIds = 0;
 
     my $uniprotCol = "accession";
     my $seqCol = $uniprotCol;
@@ -294,13 +292,6 @@ sub processQuery {
         $seqCol = "$self->{sequence_version}_seed";
         $isUniref = 1;
     }
-
-    my $rowData = sub {
-        my $row = shift;
-        # First element is N, second is C
-        my @r = ($row->{start}, $row->{end});
-        return \@r;
-    };
 
     # The retrieval process gets all IDs even if we're using UniRef so that we can get easily get
     # the domain.
@@ -313,25 +304,20 @@ sub processQuery {
         if ($isUniref) {
             # This is true when the sequence row corresponds to a UniRef sequence ID
             if ($uniprotId eq $seqId) {
-                my $domain = $rowData->($row);
+                my $domain = [ $row->{start}, $row->{end} ]; # First element is N, second is C
                 push @{ $ids->{$seqId} }, $domain;
             }
         } else {
-            my $domain = $rowData->($row);
+            my $domain = [ $row->{start}, $row->{end} ]; # First element is N, second is C
             push @{ $ids->{$seqId} }, $domain;
         }
 
-        #$uniprotUniref->{$uniprotId} = [$row->{uniref90_seed} || "", $row->{uniref50_seed} || ""];
         $uniprotUniref->{$uniprotId} = ["", ""];
 
         if (not $sequenceLengths->{$uniprotId} and defined $row->{seq_len}) {
             $sequenceLengths->{$uniprotId} = $row->{seq_len};
         }
-
-        $numIds++;
     }
-
-    return $numIds;
 }
 
 

--- a/lib/EFI/Import/Source/Family.pm
+++ b/lib/EFI/Import/Source/Family.pm
@@ -72,8 +72,6 @@ sub loadFromSource {
 
     my ($ids, $numIds, $uniprotUniref) = $self->executeQueries($queryData);
 
-    my $numFullFamily = keys %$uniprotUniref;
-
     my $numSharedSeq = $self->makeMetadata($ids, $destSeqData);
 
     # Edit the structure to get the UniRef IDs that are in the input family(s)
@@ -81,15 +79,14 @@ sub loadFromSource {
 
     # Add the UniRef IDs to the metadata file
     $self->addUnirefIds($destSeqData, $self->{sequence_version}, $uniprotUniref);
+    my $numFromFamily = 0;
 
-    $self->addStatsValue("num_ids", $numIds);
     if ($self->{sequence_version} ne SEQ_UNIPROT) {
-        $self->addStatsValue("num_full_family", $numFullFamily);
-        $self->addStatsValue("num_shared_uniref_ids", $numSharedSeq) if $numSharedSeq; # overlap between primary import source and family
+        $self->addStatsValue("num_full_family", $numIds);
     } else {
-        $self->addStatsValue("num_family", $numFullFamily);
-        $self->addStatsValue("num_shared_ids", $numSharedSeq) if $numSharedSeq; # overlap between primary import source and family
+        $self->addStatsValue("num_family", $numIds);
     }
+    $self->addStatsValue("num_shared_ids", $numSharedSeq) if $numSharedSeq; # overlap between primary import source (Accession, BLAST, FASTA) and family
 
     return $numIds;
 }

--- a/pipelines/convergenceratio/convergenceratio.nf
+++ b/pipelines/convergenceratio/convergenceratio.nf
@@ -20,14 +20,15 @@ process compute_blast_conv_ratio {
 }
 
 process merge_conv_ratios {
-    publishDir params.final_output_dir, mode: "copy", pattern: "{conv_ratio.tab}"
+    publishDir params.final_output_dir, mode: "copy", pattern: "{conv_ratio.tab,stats.json}"
 
     input:
         path stats_files
         path cr_table
 
     output:
-        path "conv_ratio.tab"
+        path "conv_ratio.tab", emit: "conv_ratio"
+        path "stats.json", emit: "stats"
 
     script:
     """
@@ -35,6 +36,7 @@ process merge_conv_ratios {
         --ssn-conv-ratio ${cr_table} \
         --stats ${stats_files} \
         --output conv_ratio.tab
+    echo "{}" > stats.json
     """
 }
 

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -345,7 +345,7 @@ workflow {
     }
 
     // Merge full and repnode SSN stats into one file
-    final_stats = merge_stats(full_ssn.stats.mix(repnode_stats).collect())
+    final_stats = merge_stats(full_ssn.stats.mix(final_ids.import_stats, repnode_stats).collect())
 
     if (params.color_ssn) {
         computed = COMPUTE_COLOR_CLUSTER_WORKFLOW(full_ssn.ssn_unzipped)

--- a/pipelines/neighborhoodconnectivity/color/color_ssn.pl
+++ b/pipelines/neighborhoodconnectivity/color/color_ssn.pl
@@ -32,7 +32,7 @@ $xwriter->write();
 
 
 if ($opts->{stats}) {
-    my $stats = $xwriter->getStats();
+    my $stats = { file_stats => $xwriter->getStats() };
     save_stats($opts->{stats}, $stats);
 }
 

--- a/pipelines/shared/condense/restore_condensed_sequences.py
+++ b/pipelines/shared/condense/restore_condensed_sequences.py
@@ -136,7 +136,7 @@ def process_cd_hit_clusters(clstr_file: str, output_path: str):
 
     # tree list contains cluster dicts with keys "rep_id" and "members"
     tree = []
-    branch = {"rep_id": "", "members" = []}
+    branch = {"rep_id": "", "members": []}
     with open(clstr_file, "r") as f:
         for line in f:
             line = line.strip()
@@ -144,7 +144,7 @@ def process_cd_hit_clusters(clstr_file: str, output_path: str):
             # degenerate sequences.
             if line.startswith(">Cluster"):
                 tree.append(branch)
-                branch = {"rep_id": "", "members" = []}
+                branch = {"rep_id": "", "members": []}
             else:
                 # match the regex pattern for the seq_id
                 matched_id = id_pattern.search(line)

--- a/pipelines/shared/import/get_sequence_ids.pl
+++ b/pipelines/shared/import/get_sequence_ids.pl
@@ -68,7 +68,6 @@ if (not $numLoaded) {
     $logger->error(@errors);
     die "\n";
 }
-my $numIds = $numLoaded;
 
 
 my $stats = new EFI::Import::Statistics();
@@ -87,8 +86,11 @@ if ($opts->{family} and $opts->{mode} ne FAMILY_SOURCE_NAME) {
     my $familySource = $sources->createSource(FAMILY_SOURCE_NAME);
     my $numFamLoaded = $familySource->loadFromSource($seqData);
     $familySource->addStats($stats);
-    $numIds += $numFamLoaded;
 }
+
+my @allIds = $seqData->getSequenceIds();
+my $numIds = scalar @allIds;
+$stats->addValue("num_ids", $numIds);  # The total collection of IDs from all sources
 
 
 my $_elapsed = int((time() - $_start) * 1000);


### PR DESCRIPTION
Properly output `stats.json` files from Neighborhood Connectivity, Convergence Ratio, and Generate SSN pipelines.  Also correct syntax errors in a python script.