### PR TITLE
Fix flipped NC SSN node attributes

### DIFF
--- a/pipelines/neighborhoodconnectivity/color/color_ssn.pl
+++ b/pipelines/neighborhoodconnectivity/color/color_ssn.pl
@@ -54,7 +54,7 @@ sub parseMappingFile {
     my %data;
     while (my $line = <$fh>) {
         chomp $line;
-        my ($id, $color, $value) = split(m/\t/, $line);
+        my ($id, $value, $color) = split(m/\t/, $line);
         $data{$id} = { color => $color, value => $value };
     }
 


### PR DESCRIPTION
The NC pipeline outputs a SSN with two new node attributes: "Neighborhood Connectivity Color" and "Neighborhood Connectivity". This PR correctly map the values into those fields (previously those fields improperly stored value and color, instead of color and value).