### PR TITLE
(Hotfix) Correct naming of taxonomy filters

### DIFF
--- a/pipelines/shared/assets/predefined_taxonomy_filters.yml
+++ b/pipelines/shared/assets/predefined_taxonomy_filters.yml
@@ -1,6 +1,6 @@
 [
     {
-        "name": "bacteria_fungi",
+        "name": "bacteria_archaea_fungi",
         "operator": "OR",
         "conditions": [
             {

--- a/pipelines/shared/assets/predefined_taxonomy_filters.yml
+++ b/pipelines/shared/assets/predefined_taxonomy_filters.yml
@@ -52,7 +52,7 @@
         ]
     },
     {
-        "name": "eukaroyta_no_fungi",
+        "name": "eukaryota_no_fungi",
         "operator": "AND",
         "conditions": [
             {


### PR DESCRIPTION
Two of the predefined taxonomy filters accessible via the website were being mapped to no filter on the backend, due to misnaming of the predefined filter json objects in `pipelines/shared/assets/predefined_taxonomy_filters.yml`. Updating those "name" keys should fix the usage of those specific taxonomy filters. 