### PR TITLE
Add create NC factor flag to generatessn params creation script

### DIFF
--- a/bin/create_generatessn_nextflow_params.py
+++ b/bin/create_generatessn_nextflow_params.py
@@ -23,6 +23,7 @@ def add_args(parser):
     ssn_args_parser.add_argument("--job-name", required=True, help="Title to be included as metadata in the XGMML file")
     ssn_args_parser.add_argument("--maxfull", default=0)
     ssn_args_parser.add_argument("--color-ssn", action="store_true", help="Numbers and colors the clusters in the SSN")
+    ssn_args_parser.add_argument("--compute-ssn-nc-factor", action="store_true", help="Numbers and colors the clusters in the SSN")
 
     # Add a subparser for automatically populating from EST output dir
     subparsers = parser.add_subparsers(dest="mode", required=True)
@@ -123,7 +124,7 @@ def render_params(blast_parquet, fasta_file, source_ids_file, seq_meta_file, out
         efi_config, db_version, job_id, efi_db, mode, ssn_name, job_name, maxfull,
         threshold_min_val,
         threshold_metric=None, min_length=None, max_length=None, sequence_filter=None,
-        color_ssn=False, **kwargs: dict):
+        color_ssn=False, compute_ssn_nc_factor=False, **kwargs: dict):
     params = {
         "blast_parquet": blast_parquet,
         "fasta_file": fasta_file,
@@ -143,6 +144,7 @@ def render_params(blast_parquet, fasta_file, source_ids_file, seq_meta_file, out
         "job_id": job_id,
         "efi_db": efi_db,
         "color_ssn": color_ssn,
+        "compute_ssn_nc_factor": compute_ssn_nc_factor,
     }
     
     # Handle kwargs dict, assuming each entry is a parameter to be added to params

--- a/tests/modules/20g_est_generatessn_nc_factor.sh
+++ b/tests/modules/20g_est_generatessn_nc_factor.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+TEST_RESULTS_DIR=$1
+CONFIG_FILE=$2
+
+self=$(basename "$0" .sh)
+OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
+
+rm -rf $OUTPUT_DIR
+
+family=$(<$EFI_TEST_FAMILY_ID)
+
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE
+bash $OUTPUT_DIR/run_nextflow.sh
+
+./bin/create_generatessn_nextflow_params.py auto --threshold-min-val 87 --ssn-name testssn --threshold-metric alignment_score --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --compute-ssn-nc-factor
+bash $OUTPUT_DIR/ssn/run_nextflow.sh
+


### PR DESCRIPTION
This PR adds a command line flag `--compute-ssn-nc-factor` to the `bin/create_generatessn_nextflow_params.py` script.  A test to verify that feature was also added.