### PR TITLE
362 add domain data to ssns

### DIFF
--- a/lib/EFI/SSN/XgmmlWriter.pm
+++ b/lib/EFI/SSN/XgmmlWriter.pm
@@ -10,7 +10,7 @@ use lib dirname(abs_path(__FILE__)) . "/../..";
 
 use EFI::Annotations;
 use EFI::Annotations::Fields qw(:annotations :source FIELD_CYTOSCAPE_COLOR);
-use EFI::Sequence::Type qw(is_unknown_sequence SEQ_FULL SEQ_DOMAIN);
+use EFI::Sequence::Type qw(is_unknown_sequence strip_domain SEQ_FULL SEQ_DOMAIN);
 
 use parent qw(EFI::Xgmml::Writer);
 
@@ -51,7 +51,7 @@ sub write {
     $self->{nb_conn} = $connectivity;
     $self->{title} = $title;
 
-    my @ids = sort $self->{metadata}->getSequenceIds();
+    my @ids = sort keys %$sequences;
 
     my $attrs = $self->getNodeAttributes(\@ids);
 
@@ -240,7 +240,7 @@ sub writeEdge {
 # Gets all of the attributes for the input nodes.
 #
 # Parameters:
-#    $ids - list of IDs in array ref
+#    $ids - list of IDs in array ref; contain domain data if the input is a domain dataset
 #
 # Returns:
 #    hash ref that maps IDs to hash refs containing attributes for the sequence
@@ -313,7 +313,7 @@ sub getFieldMetadata {
 # to populate a hash ref containing values to insert as attributes in the SSN.
 #
 # Parameters:
-#    $id - sequence ID
+#    $id - sequence ID; contains domain data if input dataset is domain
 #    $fields - hash ref of field metadata
 #
 # Returns:
@@ -325,6 +325,8 @@ sub makeNodeAttributes {
     my $id = shift;
     my $fields = shift;
 
+    my $uniprotId = strip_domain($id);
+
     my $source = "";
     my $nodeAttr = {};
 
@@ -332,7 +334,7 @@ sub makeNodeAttributes {
         # Skip any sequence defined in the metadata file
         next if $field eq FIELD_SEQ_KEY;
 
-        my $value = $self->{metadata}->getSequence($id)->getAttribute($field, 1);
+        my $value = $self->{metadata}->getSequence($uniprotId)->getAttribute($field, 1);
         $value = MISSING_VALUE if not $value;
         $source = $value if $field eq FIELD_SEQ_SRC_KEY;
 

--- a/lib/EFI/Sequence/Type.pm
+++ b/lib/EFI/Sequence/Type.pm
@@ -54,8 +54,8 @@ sub get_sequence_type {
 
 sub strip_domain {
     my $id = shift;
-    $id =~ s/^([^\:]+):\d+:\d+$/$1/;
-    return $id;
+    my $colonPos = index($id, ":");
+    return $colonPos > -1 ? substr($id, 0, $colonPos) : $id;
 }
 
 

--- a/pipelines/generatessn/create/create_ssn.pl
+++ b/pipelines/generatessn/create/create_ssn.pl
@@ -81,12 +81,13 @@ sub updateForRepnode {
 
     foreach my $clusterId (keys %$clusters) {
         my $clusterNodeId = strip_domain($clusters->{$clusterId}->{representative});
-        my @members = grep { $_ ne $clusterNodeId } map { strip_domain($_) } @{ $clusters->{$clusterId}->{members} };
+        my @clusterMembers = grep { strip_domain($_) ne $clusterNodeId } @{ $clusters->{$clusterId}->{members} };
+        my @metaMembers = map { strip_domain($_) } @clusterMembers;
 
         # Update the collection to merge IDs and node attributes into a single cluster
-        $inputIds->mergeSequences($clusterNodeId, @members);
+        $inputIds->mergeSequences($clusterNodeId, @metaMembers);
 
-        foreach my $id (@members) {
+        foreach my $id (@clusterMembers) {
             delete $sequences->{$id};
             delete $connectivity->{$id};
         }


### PR DESCRIPTION
Support domain sequence IDs in the SSN output, full and repnode.

- Use FASTA file as the source of the IDs, not the node metadata file
- Use shared metadata from the UniProt ID for each domain ID that shares the UniProt ID
- Edges isn't safe to get node IDs from, because it will ignore singletons
- Also optimize `strip_domain` function since it will be called many times