### PR TITLE
366 - Fix "eukaryota_no_fungi" predef taxonomy filter

### DIFF
--- a/pipelines/shared/assets/predefined_taxonomy_filters.yml
+++ b/pipelines/shared/assets/predefined_taxonomy_filters.yml
@@ -62,27 +62,27 @@
             {
                 "field": "phylum",
                 "value": "Ascomycota",
-                "operator": "NOT"
+                "negate": "true"
             },
             {
                 "field": "phylum",
                 "value": "Basidiomycota",
-                "operator": "NOT"
+                "negate": "true"
             },
             {
                 "field": "phylum",
                 "value": "Fungi incertae sedis",
-                "operator": "NOT"
+                "negate": "true"
             },
             {
                 "field": "phylum",
                 "value": "unclassified Fungi",
-                "operator": "NOT"
+                "negate": "true"
             },
             {
                 "field": "species",
                 "value": "%metagenome%",
-                "operator": "NOT",
+                "negate": "true",
                 "exact": false
             }
         ]


### PR DESCRIPTION
Fixes the json formatting of the taxonomy filter to use the "negate" keyword instead of the "operator" keyword for the "condition" elements. Still needs to be tested.

Closes #366 