### PR TITLE
368 order length histogram input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV PATH="${PATH}:/opt/cd-hit-v4.8.1-2019-0228/bin"
 
 # install SeqKit
 RUN mkdir -p /opt/seqkit && \
-    curl -L -o /opt/seqkit/seqkit.tar.gz https://github.com/shenwei356/seqkit/releases/download/v2.12.0/seqkit_linux_amd64.tar.gz && \
+    curl -L -o /opt/seqkit/seqkit.tar.gz https://github.com/shenwei356/seqkit/releases/download/v2.13.0/seqkit_linux_amd64.tar.gz && \
     tar -zxvf /opt/seqkit/seqkit.tar.gz -C /opt/seqkit && \
     rm /opt/seqkit/seqkit.tar.gz
 ENV PATH="${PATH}:/opt/seqkit"

--- a/lib/pyEFI/pyEFI/processing.py
+++ b/lib/pyEFI/pyEFI/processing.py
@@ -22,6 +22,11 @@ def count_lengths(count_file: str, frac: float) -> pd.DataFrame:
         A pandas DataFrame object with "count" and "length" columns
     """
     df = pd.read_csv(count_file, sep='\s+')
+
+    # sort numerically, in case the data didn't come in sorted
+    df["length"] = pd.to_numeric(df["length"])
+    df = df.sort_values(by="length").reset_index(drop=True)
+
     df["sequence_sum"] = df["count"].cumsum()
     # trim values using --frac value
     end_trim = int(df["count"].sum() * (1.0 - frac) / 2.0)

--- a/pipelines/shared/visualization/compute_length_histogram.py
+++ b/pipelines/shared/visualization/compute_length_histogram.py
@@ -196,7 +196,7 @@ def compute_histogram(sequence_lengths: List[int], output_file: str, seq_type: s
     if not sequence_lengths:
         print(f"Warning: No sequences were selected for histogram generation{seq_type_str}. Output will be empty.", file=sys.stderr)
 
-    length_counts = Counter(sequence_lengths)
+    length_counts = Counter(int(length) for length in sequence_lengths)
 
     with open(output_file, 'w') as f_out:
         f_out.write("length\tcount\n")


### PR DESCRIPTION
This PR includes a change to support a newer version of seqkit in Dockerfile.  The version used in deployments is 2.13 but the Docker version 2.12, and the newer one supports a flag that has been added in recent iterations.  This PR also fixes length histogram plot issues by ordering the histogram data, both when written to a file and loaded for plotting.