### PR TITLE
Track all IDs in sequence collection

### DIFF
--- a/lib/EFI/Sequence/Collection.pm
+++ b/lib/EFI/Sequence/Collection.pm
@@ -391,7 +391,7 @@ sub loadIdFile {
     while (my $line = <$fh>) {
         chomp $line;
         my ($uniprot, $uniref90, $uniref50) = split(m/\t/, $line);
-        $self->associateUnirefIds($uniprot, $uniref90, $uniref50) if $uniref90 and $uniref50;
+        $self->associateUnirefIds($uniprot, $uniref90 // "", $uniref50 // "");
     }
 
     $fh->close();


### PR DESCRIPTION
- IDs without UniRef data were improperly excluded from filters
- This update ensures that all UniProt IDs are included in sequence filtering, even if they don't have UniRef data
- This bug occurred in a few edge cases, when using a family job; UniProt IDs that were in the family intentionally do not include UniRef IDs that are not part of the family