### PR TITLE
373 fasta option ssns have no edges

### DIFF
--- a/lib/EFI/Import/Config/Defaults.pm
+++ b/lib/EFI/Import/Config/Defaults.pm
@@ -22,6 +22,7 @@ my %files = (
     accession_table => "accession_table.tab",
     import_stats => "import_stats.json",
     retrieval_ids => "retrieval_ids.tab",
+    master_ids => "master_ids.tab",
 
     # output from get_sunburst_data.pl
     sunburst_ids => "sunburst_ids.tab",

--- a/lib/EFI/Import/Config/Filter.pm
+++ b/lib/EFI/Import/Config/Filter.pm
@@ -45,6 +45,7 @@ sub addImportOptions {
     $self->addOption("source-stats-file=s", 0, "path to the file containing source import stats", OPT_FILE);
     $self->addOption("stats-file=s", 0, "path to the file to save filter statistics to (appends to source stats)", OPT_FILE);
     $self->addOption("retrieval-ids-file=s", 0, "path to the file to save IDs that are for retrieving, as opposed to those sequences in a user-specified FASTA", OPT_FILE);
+    $self->addOption("master-ids-file=s", 0, "path to the file to save the master list of primary IDs", OPT_FILE);
 }
 
 
@@ -88,6 +89,7 @@ sub validateOptions {
     $opts->{source_stats_file} = get_default_path("source_stats", $outputDir) if not $opts->{source_stats_file};
     $opts->{stats_file} = get_default_path("import_stats", $outputDir) if not $opts->{stats_file};
     $opts->{retrieval_ids_file} = get_default_path("retrieval_ids", $outputDir) if not $opts->{retrieval_ids_file};
+    $opts->{master_ids_file} = get_default_path("master_ids", $outputDir) if not $opts->{master_ids_file};
 
     if (@errors) {
         my $help = $self->printHelp(\@errors);

--- a/lib/EFI/SSN/XgmmlWriter.pm
+++ b/lib/EFI/SSN/XgmmlWriter.pm
@@ -9,7 +9,7 @@ use File::Basename;
 use lib dirname(abs_path(__FILE__)) . "/../..";
 
 use EFI::Annotations;
-use EFI::Annotations::Fields qw(:annotations :source FIELD_CYTOSCAPE_COLOR);
+use EFI::Annotations::Fields qw(:annotations :source);
 use EFI::Sequence::Type qw(is_unknown_sequence strip_domain SEQ_FULL SEQ_DOMAIN);
 
 use parent qw(EFI::Xgmml::Writer);
@@ -267,6 +267,14 @@ sub getNodeAttributes {
     # we need to add the sequence field as an attribute to the SSN.  $self->{hash_fasta_attribute}
     # is set in makeNodeAttributes if this attribute is found.
     $fieldMeta{&FIELD_SEQ_KEY} = $self->getFieldMetadata(FIELD_SEQ_KEY, $anno) if $self->{has_fasta_attribute};
+
+    # Add neighborhood connectivity colors
+    if ($self->{nb_conn}) {
+        $fieldMeta{&FIELD_NB_CONN} = $self->getFieldMetadata(FIELD_NB_CONN, $anno);
+        $fieldMeta{&FIELD_NB_CONN_COLOR} = $self->getFieldMetadata(FIELD_NB_CONN_COLOR, $anno);
+        $fieldMeta{&FIELD_NB_CONN_PRIMARY_COLOR} = $self->getFieldMetadata(FIELD_NB_CONN_PRIMARY_COLOR, $anno);
+    }
+
     my @fields = $anno->sort_annotations(keys %fieldMeta);
 
     $self->{fields} = [];
@@ -365,7 +373,7 @@ sub makeNodeAttributes {
         $nodeAttr->{&FIELD_NB_CONN} = $nc->{nc};
         if ($nc->{color}) {
             $nodeAttr->{&FIELD_NB_CONN_COLOR} = $nc->{color};
-            $nodeAttr->{&FIELD_CYTOSCAPE_COLOR} = $nc->{color};
+            $nodeAttr->{&FIELD_NB_CONN_PRIMARY_COLOR} = $nc->{color};
         }
     }
 

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -301,10 +301,10 @@ workflow {
     // Filter sequences out by length or other criteria (e.g. fragment, taxonomy)
     final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, Channel.value([]))
 
-    filtered_fasta = filter_fasta(input_data.fasta, final_ids.retrieval_ids)
+    filtered_fasta = filter_fasta(input_data.fasta, final_ids.master_ids)
 
     // Apply threshold to BLAST file
-    thresholded_blast = threshold_blast(input_data.blast_output, final_ids.retrieval_ids)
+    thresholded_blast = threshold_blast(input_data.blast_output, final_ids.master_ids)
 
     // Get annotations
     ssn_meta_file = get_annotations(final_ids.sequence_metadata)

--- a/pipelines/shared/import/filter_ids.pl
+++ b/pipelines/shared/import/filter_ids.pl
@@ -127,6 +127,12 @@ map { $rfh->print("$_\n"); } @retrievalIds;
 close $rfh;
 
 
+# Save master ID list, of all "primary" IDs (e.g. if input is UniRef, UniRef IDs).  Needed by
+# SSN pipeline
+my @masterIds = $seqData->getSequenceIds();
+open my $mfh, ">", $opts->{master_ids_file} or die "Unable to write to master IDs file '$opts->{master_ids_file}': $!";
+map { $mfh->print("$_\n"); } @masterIds;
+close $mfh;
 
 
 $stats->save($opts->{stats_file});
@@ -224,6 +230,7 @@ B<filter_ids.pl> - filter IDs from the original input files and create a ID retr
     #     --sequence-meta-file sequence_metadata.tab    # output
     #     --stats-file import_stats.tab                 # output
     #     --retrieval-ids-file retrieval_ids.tab        # output
+    #     --master-ids-file master_ids.tab              # output
 
     
 

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -27,6 +27,7 @@ process filter_ids {
         path 'sequence_metadata.tab', emit: 'sequence_metadata' // sequence metdata in metadata format
         path 'import_stats.json', emit: 'import_stats'          // final statistics of source and filter import processes
         path 'retrieval_ids.tab', emit: 'retrieval_ids'         // list of IDs that came from the database, as opposed to user-specified FASTA files, including domain data
+        path 'master_ids.tab', emit: 'master_ids'               // list of all primary IDs in the dataset
     script:
     def xids_file = explicit_ids_file ? "--filter explicit-ids-file=${explicit_ids_file}" : ""
     def filter_args = formatFilterArgs(params.filter)
@@ -42,6 +43,7 @@ process filter_ids {
         --accession-table-file accession_table.tab \
         --sequence-meta-file sequence_metadata.tab \
         --retrieval-ids-file retrieval_ids.tab \
+        --master-ids-file master_ids.tab \
         --stats-file import_stats.json \
         ${filter_args} ${user_filter_arg} \
         ${xids_file}


### PR DESCRIPTION
This PR solves two issues:

* Edges were missing when generating FASTA SSNs.  This is fixed in this PR by avoiding the use of the `retrieval_ids` file and creating a new master IDs file that is used to perform SSN filtering.
* The NC factor and color are now added to SSNs, if the user enables nc computation during generatessn.