### PR TITLE
372 - Repnode associated process block configuration

### DIFF
--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -14,7 +14,7 @@ params {
     duckdb_memory_limit = "8GB"
     duckdb_threads = 1
     duckdb_temp_dir = "duckdb"
-    cdhit_memory_limit = 10000	// units: MB
+    cdhit_memory_limit = "10 GB"
     num_accession_shards = 64
     import_blast_fasta_db = null
     input_file = null

--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -32,6 +32,7 @@ params {
     repnode_pct = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50] 
     max_ssn_edges = 200000000
     compute_ssn_nc_factor = false
+    color_ssn = true
 
     // GNT/GND parameters
     nb_size = 20

--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -17,7 +17,7 @@ params {
     duckdb_memory_limit = "8GB"
     duckdb_threads = 1
     duckdb_temp_dir = "duckdb"
-    cdhit_memory_limit = "10 GB"
+    cdhit_memory_limit = 10.GB
     num_accession_shards = 64
     import_blast_fasta_db = null
     input_file = null

--- a/conf/default_params.config
+++ b/conf/default_params.config
@@ -1,5 +1,8 @@
 
 params {
+    // compute resource specific parameters
+    compute_local_storage = "/tmp"
+
     // EST parameters
     sequence_version = "uniprot"
     domain = false

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -22,6 +22,11 @@ process {
         memory = params.cdhit_memory_limit
     }
 
+    withLabel: 'TASK_create_ssn' {
+        cpus = 1
+        memory = '20 GB' // is this enough?
+    }
+
 
 
 

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -6,6 +6,11 @@ nextflow.enable.configProcessNamesValidation = false
 
 docker.enabled = true
 
+/*
+Include a config file containing the default values for workflows
+*/
+includeConfig './default_params.config'
+
 process {
     cpus = 1
     memory = 5.GB
@@ -19,11 +24,8 @@ process {
 
     withLabel: 'TASK_create_ssn' {
         cpus = 1
-        memory = '20 GB' // is this enough?
+        memory = '20 GB'
     }
-
-
-
 
     withName: blastreduce {
         memory = 20.GB
@@ -41,9 +43,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -24,7 +24,7 @@ process {
 
     withLabel: 'TASK_create_ssn' {
         cpus = 1
-        memory = '20 GB'
+        memory = 20.GB
     }
 
     withName: blastreduce {

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -6,11 +6,24 @@ nextflow.enable.configProcessNamesValidation = false
 
 docker.enabled = true
 
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
+
 process {
     cpus = 1
     memory = 5.GB
     container = 'enzymefunctioninitiative/efi-est:latest'
     containerOptions = "-v $projectDir:$projectDir -v $projectDir/../shared:$projectDir/../shared -v $projectDir/../../lib:$projectDir/../../lib -v $EFI_DATA_DIR:$EFI_DATA_DIR"
+
+    withLabel: 'APP_cd_hit' {
+        cpus = 2
+        memory = params.cdhit_memory_limit
+    }
+
+
+
 
     withName: blastreduce {
         memory = 20.GB
@@ -28,9 +41,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -6,11 +6,6 @@ nextflow.enable.configProcessNamesValidation = false
 
 docker.enabled = true
 
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
-
 process {
     cpus = 1
     memory = 5.GB
@@ -46,4 +41,9 @@ process {
         cpus = 1
     }
 }
+
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
 

--- a/conf/pbspro.config
+++ b/conf/pbspro.config
@@ -25,6 +25,12 @@ process {
         memory = params.cdhit_memory_limit
     }
 
+    withLabel: 'TASK_create_ssn' {
+        executor = 'pbspro'
+        cpus = 1
+        memory = '20 GB' // is this enough?
+    }
+
 
 
 

--- a/conf/pbspro.config
+++ b/conf/pbspro.config
@@ -31,7 +31,7 @@ process {
         executor = 'pbspro'
         queue = 'normal'
         cpus = 1
-        memory = '20 GB'
+        memory = 20.GB
     }
 
     withName: all_by_all_blast {

--- a/conf/pbspro.config
+++ b/conf/pbspro.config
@@ -9,10 +9,24 @@ executor {
     queueSize = 64
 }
 
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
+
 process {
     executor = 'local'
     cpus = 1
     memory = 5.GB
+
+    withLabel: 'APP_cd_hit' {
+        executor = 'pbspro'
+        cpus = 2
+        memory = params.cdhit_memory_limit
+    }
+
+
+
 
     withName: all_by_all_blast {
         executor = 'pbspro'
@@ -42,9 +56,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/pbspro.config
+++ b/conf/pbspro.config
@@ -9,11 +9,6 @@ executor {
     queueSize = 64
 }
 
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
-
 process {
     executor = 'local'
     cpus = 1
@@ -62,4 +57,9 @@ process {
         cpus = 1
     }
 }
+
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
 

--- a/conf/pbspro.config
+++ b/conf/pbspro.config
@@ -6,8 +6,14 @@ nextflow.enable.configProcessNamesValidation = false
 
 executor {
     name = 'pbspro'
+    queue = 'normal'
     queueSize = 64
 }
+
+/*
+Include a config file containing the default values for workflows
+*/
+includeConfig './default_params.config'
 
 process {
     executor = 'local'
@@ -16,28 +22,29 @@ process {
 
     withLabel: 'APP_cd_hit' {
         executor = 'pbspro'
+        queue = 'normal'
         cpus = 2
         memory = params.cdhit_memory_limit
     }
 
     withLabel: 'TASK_create_ssn' {
         executor = 'pbspro'
+        queue = 'normal'
         cpus = 1
-        memory = '20 GB' // is this enough?
+        memory = '20 GB'
     }
-
-
-
 
     withName: all_by_all_blast {
         executor = 'pbspro'
+        queue = 'normal'
         memory = 2.GB
         time = 24.h
     }
 
     withName: blastreduce {
         executor = 'pbspro'
-	    cpus = 4
+        queue = 'normal'
+        cpus = 4
         memory = 20.GB
         time = 24.h
     }
@@ -54,12 +61,8 @@ process {
 
     withLabel: muscle_align {
         executor = 'pbspro'
+        queue = 'normal'
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/pbstorque.config
+++ b/conf/pbstorque.config
@@ -10,10 +10,23 @@ executor {
     queueSize = 64
 }
 
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
+
 process {
     executor = 'local'
     cpus = 1
     memory = 5.GB
+
+    withLabel: 'APP_cd_hit' {
+        executor = 'pbs'
+        cpus = 2
+        memory = params.cdhit_memory_limit
+    }
+
+
 
     withName: all_by_all_blast {
         executor = 'pbs'
@@ -52,9 +65,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/pbstorque.config
+++ b/conf/pbstorque.config
@@ -31,7 +31,7 @@ process {
         executor = 'pbs'
         queue = 'normal'
         cpus = 1
-        memory = '20 GB'
+        memory = 20.GB
     }
 
     withName: all_by_all_blast {

--- a/conf/pbstorque.config
+++ b/conf/pbstorque.config
@@ -10,6 +10,11 @@ executor {
     queueSize = 64
 }
 
+/*
+Include a config file containing the default values for workflows
+*/
+includeConfig './default_params.config'
+
 process {
     executor = 'local'
     cpus = 1
@@ -17,17 +22,17 @@ process {
 
     withLabel: 'APP_cd_hit' {
         executor = 'pbs'
+        queue = 'normal'
         cpus = 2
         memory = params.cdhit_memory_limit
     }
 
     withLabel: 'TASK_create_ssn' {
         executor = 'pbs'
+        queue = 'normal'
         cpus = 1
-        memory = '20 GB' // is this enough?
+        memory = '20 GB'
     }
-
-
 
     withName: all_by_all_blast {
         executor = 'pbs'
@@ -66,9 +71,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/pbstorque.config
+++ b/conf/pbstorque.config
@@ -10,11 +10,6 @@ executor {
     queueSize = 64
 }
 
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
-
 process {
     executor = 'local'
     cpus = 1
@@ -71,4 +66,9 @@ process {
         cpus = 1
     }
 }
+
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
 

--- a/conf/pbstorque.config
+++ b/conf/pbstorque.config
@@ -26,6 +26,12 @@ process {
         memory = params.cdhit_memory_limit
     }
 
+    withLabel: 'TASK_create_ssn' {
+        executor = 'pbs'
+        cpus = 1
+        memory = '20 GB' // is this enough?
+    }
+
 
 
     withName: all_by_all_blast {

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -22,6 +22,11 @@ process {
         memory = params.cdhit_memory_limit
     }
 
+    withLabel: 'TASK_create_ssn' {
+        cpus = 1
+        memory = '20 GB' // is this enough?
+    }
+
 
 
 

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -6,6 +6,11 @@ nextflow.enable.configProcessNamesValidation = false
 
 singularity.enabled = true
 
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
+
 process {
     cpus = 1
     memory = 5.GB
@@ -19,11 +24,8 @@ process {
 
     withLabel: 'TASK_create_ssn' {
         cpus = 1
-        memory = '20 GB' // is this enough?
+        memory = '20 GB'
     }
-
-
-
 
     withName: 'color_ssn|create_gnd|create_gnns|color_gnt_ssn|compute_clusters' {
         memory = 10.GB
@@ -41,9 +43,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -24,7 +24,7 @@ process {
 
     withLabel: 'TASK_create_ssn' {
         cpus = 1
-        memory = '20 GB'
+        memory = 20.GB
     }
 
     withName: 'color_ssn|create_gnd|create_gnns|color_gnt_ssn|compute_clusters' {

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -6,11 +6,6 @@ nextflow.enable.configProcessNamesValidation = false
 
 singularity.enabled = true
 
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
-
 process {
     cpus = 1
     memory = 5.GB
@@ -46,4 +41,9 @@ process {
         cpus = 1
     }
 }
+
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
 

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -6,11 +6,24 @@ nextflow.enable.configProcessNamesValidation = false
 
 singularity.enabled = true
 
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
+
 process {
     cpus = 1
     memory = 5.GB
     container = 'enzymefunctioninitiative/efi-est:latest'
     containerOptions = "--bind $projectDir:$projectDir --bind $projectDir/../shared:$projectDir/../shared --bind $projectDir/../../:$projectDir/../../ --bind $projectDir/../../lib:$projectDir/../../lib --bind $EFI_DATA_DIR:$EFI_DATA_DIR"
+
+    withLabel: 'APP_cd_hit' {
+        cpus = 2
+        memory = params.cdhit_memory_limit
+    }
+
+
+
 
     withName: 'color_ssn|create_gnd|create_gnns|color_gnt_ssn|compute_clusters' {
         memory = 10.GB
@@ -28,9 +41,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -4,11 +4,6 @@ report.overwrite = true
 nextflow.preview.output = true
 nextflow.enable.configProcessNamesValidation = false
 
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
-
 executor {
     name = 'slurm'
     queue = 'efi'
@@ -67,4 +62,9 @@ process {
         cpus = 1
     }
 }
+
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -17,12 +17,14 @@ process {
 
     withLabel: 'APP_cd_hit' {
         executor = 'slurm'
+        queue = 'efi'
         cpus = 2
         memory = params.cdhit_memory_limit
     }
 
     withLabel: 'TASK_create_ssn' {
         executor = 'slurm'
+        queue = 'efi'
         cpus = 1
         memory = '20 GB' // is this enough?
 	scratch = params.compute_local_storage

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -31,7 +31,7 @@ process {
         executor = 'slurm'
         queue = 'efi'
         cpus = 1
-        memory = '20 GB'
+        memory = 20.GB
         scratch = params.compute_local_storage
     }
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -4,6 +4,11 @@ report.overwrite = true
 nextflow.preview.output = true
 nextflow.enable.configProcessNamesValidation = false
 
+/*
+Include a config file containing the default values for workflows
+*/ 
+includeConfig './default_params.config'
+
 executor {
     name = 'slurm'
     queue = 'efi'
@@ -14,6 +19,25 @@ process {
     executor = 'local'
     cpus = 1
     memory = 5.GB
+
+    withLabel: 'APP_cd_hit' {
+        executor = 'slurm'
+        cpus = 2
+        memory = params.cdhit_memory_limit
+    }
+
+
+
+
+    withLabel: create_ssn {
+        executor = 'slurm'
+        memory = 2.GB
+    }
+
+
+
+
+
 
     withName: all_by_all_blast {
         executor = 'slurm'
@@ -45,9 +69,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -25,6 +25,7 @@ process {
         executor = 'slurm'
         cpus = 1
         memory = '20 GB' // is this enough?
+	scratch = params.compute_local_storage
     }
 
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -26,12 +26,10 @@ process {
         memory = params.cdhit_memory_limit
     }
 
-
-
-
-    withLabel: create_ssn {
+    withLabel: 'TASK_create_ssn' {
         executor = 'slurm'
-        memory = 2.GB
+        cpus = 1
+        memory = '20 GB' // is this enough?
     }
 
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -10,6 +10,11 @@ executor {
     queueSize = 128
 }
 
+/*
+Include a config file containing the default values for workflows
+*/
+includeConfig './default_params.config'
+
 process {
     executor = 'local'
     cpus = 1
@@ -26,14 +31,9 @@ process {
         executor = 'slurm'
         queue = 'efi'
         cpus = 1
-        memory = '20 GB' // is this enough?
-	scratch = params.compute_local_storage
+        memory = '20 GB'
+        scratch = params.compute_local_storage
     }
-
-
-
-
-
 
     withName: all_by_all_blast {
         executor = 'slurm'
@@ -65,9 +65,4 @@ process {
         cpus = 1
     }
 }
-
-/*
-Include a config file containing the default values for workflows
-*/ 
-includeConfig './default_params.config'
 

--- a/pipelines/clusteranalysis/subworkflows/prepare.nf
+++ b/pipelines/clusteranalysis/subworkflows/prepare.nf
@@ -37,6 +37,7 @@ process count_fasta {
 }
 
 process cdhit_reduce {
+    label 'APP_cd_hit'
     tag "ca_cdhit_${id}"
 
     input:
@@ -50,7 +51,12 @@ process cdhit_reduce {
 
     """
     # Using legacy parameters: -c 1 -s 1 -M 14900
-    cd-hit -c 1 -s 1 -i ${fasta} -o ${id}_cdhit.fasta -M ${params.cdhit_memory_limit}
+    # ^^^ not using the -M memory setting
+    cd-hit -c 1 -s 1 \
+           -i ${fasta} \
+           -o ${id}_cdhit.fasta \
+           -M ${task.memory.toMega()} \
+           -T ${task.cpus}
     """
 }
 

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -153,7 +153,7 @@ process create_full_ssn {
 }
 
 process create_repnode_ssns {
-    label 'create_ssn'
+    label 'TASK_create_ssn'
 
     publishDir params.final_output_dir, mode: 'copy', pattern: "*.{zip}"
 

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -153,6 +153,8 @@ process create_full_ssn {
 }
 
 process create_repnode_ssns {
+    label 'create_ssn'
+
     publishDir params.final_output_dir, mode: 'copy', pattern: "*.{zip}"
 
     input:

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -195,6 +195,8 @@ process create_repnode_ssns {
 }
 
 process compute_repnode_cdhit {
+    label 'APP_cd_hit'
+
     input:
         path all_fasta
         val repnode_pct
@@ -217,7 +219,14 @@ process compute_repnode_cdhit {
     //else { word_opt = 5 }
 
     """
-    cd-hit -n ${word_opt} ${length_overlap_opt} -i ${all_fasta} -o cdhit_${repnode_pct} -c ${cdhit_pct} -d 0 ${algo_opt} ${bandwidth_opt}
+    cd-hit -d 0 -c ${cdhit_pct} \
+           ${length_overlap_opt} \
+           -n ${word_opt} \
+           -i ${all_fasta} \
+           -o cdhit_${repnode_pct} \
+           ${algo_opt} ${bandwidth_opt} \
+           -M ${task.memory.toMega()} \
+           -T ${task.cpus}
     """
 }
 

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -111,6 +111,8 @@ process get_annotations {
 }
 
 process create_full_ssn {
+    label 'TASK_create_ssn'
+
     publishDir params.final_output_dir, mode: 'copy', pattern: "*.{zip}"
 
     input:

--- a/pipelines/shared/nextflow/blast.nf
+++ b/pipelines/shared/nextflow/blast.nf
@@ -96,6 +96,8 @@ process blastreduce_transcode_fasta {
 
 // Formerly known as multiplex
 process condense_redundant {
+    label 'APP_cd_hit'
+
     input:
         tuple val(fid), path(fasta_file)
 
@@ -105,11 +107,11 @@ process condense_redundant {
 
     script:
     """
-    cd-hit \
-        -d 0 -c 1 -s 1 \
-        -i ${fasta_file} \
-        -o sequences.fasta \
-        -M "${params.cdhit_memory_limit}"
+    cd-hit -d 0 -c 1 -s 1 \
+           -i ${fasta_file} \
+           -o sequences.fasta \
+           -M ${task.memory.toMega()} \
+           -T ${task.cpus}
     """
 }
 


### PR DESCRIPTION
- [x] Each repnode has a cd-hit call, which has a hardcoded memory allocation (set by `-M` parameter). The associated process blocks for cd-hit calls generally used the standard `"local"` executor, which did or did not have a predefined memory allocation. This resulted in the cd-hit expected memory allocation to be out of sync with the available memory allocation given to the process block. Instead, the cd-hit process blocks have been given a label `APP_cd_hit`, which tells them to use the scheduler executor (when relevant) and explicitly defines a memory and thread allocation for processes with that label.
- [x] The `TASK_create_ssn` label has been added. When relevant, this label ensures that the `create_repnode_ssn` process block is performed 11 times in perfectly parallel strategy rather than being done serially on the `"local"` executor.
- [x] ~~An element of the XGMML writer seems to be a slow down. Find that bottleneck and make it more efficient.~~ See #376 for further investigation into this software bottleneck. This fix is beyond the scope of the current PR.

There's some interesting development that can happen with the config file work started here. ~~Nextflow handling of parameters is done \_before\_ process block configuration is cemented and applied during the workflow, so if we wanted to dynamically handle resource allocations for memory/cpu-hungry process blocks, we could do so in various ways and at various levels.~~ Edit: I'm not sure this is true. I need to at least call the `includeConfig` call before `process { ... }` configuration block in the central configuration file, otherwise nextflow doesn't know what `params.cd_hit_memory` is (for example). 

For example, if we wanted jobs to run on high memory nodes, the whole job doesn't necessarily need to run on that high-mem compute resource. Instead, we can identify the process blocks that require high memory and set the process' `"queue"` to be "efi-mem" or equivalent on other implementations. This could enable us to process large SSNs and avoid any sort of hard-cutoff for input data. Edit: Considering the above edit, this statement should still be possible because we can overwrite the parameters' values from those in the `default_params.config` to ones written explicitly in the `params.json` file.