### PR TITLE
376 ssn performance optimization buffer

### DIFF
--- a/lib/EFI/Import/SequenceDB.pm
+++ b/lib/EFI/Import/SequenceDB.pm
@@ -170,8 +170,6 @@ file.  Domain regions can be optionally specified.
 
 =head3 C<new(fasta_db =E<gt> $fastaDbPath)>
 
-Creates a new B<EFI::SSN::XgmmlReader> object.
-
 =head4 Parameters
 
 =over

--- a/lib/EFI/SSN/XgmmlReader.pm
+++ b/lib/EFI/SSN/XgmmlReader.pm
@@ -14,7 +14,6 @@ sub new {
     bless($self, $class);
 
     $self->{domain_idx} = {};
-    $self->{edgelist} = [];
     $self->{input} = $args{xgmml_file};
     $self->{id_idx} = {};
     $self->{idx_seqid} = {};
@@ -24,12 +23,6 @@ sub new {
     $self->{metadata_only} = $args{metadata_only} // 0;
 
     return $self;
-}
-
-
-sub getEdgeList {
-    my $self = shift;
-    return $self->{edgelist};
 }
 
 
@@ -59,56 +52,44 @@ sub getDomainIndexMap {
 
 sub parse {
     my $self = shift;
+    my %args = @_;
 
     my $reader = XML::LibXML::Reader->new(location => $self->{input}) or die "cannot read $self->{input}\n";
     $self->{current_node_id} = "";
-    while ($reader->read) {
-        my $continueParsing = $self->processXmlNode($reader);
-        last if not $continueParsing;
+
+    my $id_idx = $self->{id_idx};
+
+    my $edgelistFh;
+    if ($args{edgelist_file}) {
+        open $edgelistFh, ">", $args{edgelist_file} or die "Unable to open edgelist file '$args{edgelist_file}' for writing: $!";
     }
-}
 
+    my $TYPE_ELEMENT = XML_READER_TYPE_ELEMENT;
 
-#
-# processXmlNode - private method
-#
-# Processes a XML node (a XGMML 'edge', 'node', or 'att' tag). Called for every
-# type of XML element encountered, but only the start node or empty nodes are
-# processed.
-#
-# Parameters:
-#    $reader - XML::LibXML::Reader object (points to current XML node)
-#
-# Returns:
-#    non-zero if ok to continue parsing, zero to terminate parsing
-#
-sub processXmlNode {
-    my $self = shift;
-    my $reader = shift;
-    my $ntype = $reader->nodeType;
-    my $nname = $reader->name;
+    while ($reader->read) {
+        my $ntype = $reader->nodeType;
+        next if $ntype != $TYPE_ELEMENT;
 
-    return 1 if $ntype == XML_READER_TYPE_WHITESPACE || $ntype == XML_READER_TYPE_SIGNIFICANT_WHITESPACE;
+        my $nname = $reader->name;
 
-    if ($ntype == XML_READER_TYPE_ELEMENT) {
-        if ($nname eq "node") {
+        if ($nname eq "edge") {
+            my $source = $reader->getAttribute("source");
+            my $target = $reader->getAttribute("target");
+            $edgelistFh->print($id_idx->{$source}, " ", $id_idx->{$target}, "\n");
+        } elsif ($nname eq "node") {
             $self->processNode($reader);
         } elsif ($nname eq "att") {
             # An 'empty' element is a leaf (e.g. no child elements; <att X="Y" /> is empty)
             if ($reader->isEmptyElement()) {
                 $self->processAtt($reader);
             }
-        } elsif ($nname eq "edge") {
-            $self->processEdge($reader);
         } elsif ($nname eq "graph") {
             $self->processGraph($reader);
-            if ($self->{metadata_only}) {
-                return 0;
-            }
+            last if $self->{metadata_only};
         }
     }
 
-    return 1;
+    close $edgelistFh if $edgelistFh;
 }
 
 
@@ -151,28 +132,6 @@ sub processGraph {
     my $reader = shift;
     my $label = $reader->getAttribute("label") // "";
     $self->{ssn_metadata}->{title} = $label;
-}
-
-
-#
-# processEdge - private method
-#
-# Processes a XGMML 'edge' element by extracting the source and target node IDs.
-# Adds the edge (which consists of a source and target node) to the edgelist.
-# Note that this is the node 'id' attribute which is not necessarily the
-# sequence ID (e.g. label). 
-#
-# Parameters:
-#    $reader - XML::LibXML::Reader object (points to current XML node)
-#
-sub processEdge {
-    my $self = shift;
-    my $reader = shift;
-    my $source = $reader->getAttribute("source");
-    my $target = $reader->getAttribute("target");
-    my $sidx = $self->{id_idx}->{$source};
-    my $tidx = $self->{id_idx}->{$target};
-    push @{ $self->{edgelist} }, [$sidx, $tidx];
 }
 
 
@@ -238,11 +197,9 @@ EFI::SSN::XgmmlReader - Perl utility module for extracting network information f
     my $parser = EFI::SSN::XgmmlReader->new(xgmml_file => $ssnFile);
     $parser->parse();
 
-    my $edgelist = $parser->getEdgeList();
     my $indexSeqIdMap = $parser->getIndexSeqIdMap();
     my $idIndexMap = $parser->getIdIndexMap();
 
-    map { print join(" ", @$_), "\n"; } @$edgelist;
     map { print join("\t", $_, $indexSeqIdMap->{$_}), "\n"; } keys %$indexSeqIdMap;
     map { print join("\t", $_, $idIndexMap->{$_}), "\n"; } sort keys %$idIndexMap;
 
@@ -307,22 +264,6 @@ immediately after obtaining SSN metadata.
 =head4 Example Usage
 
     $parser->parse();
-
-
-=head3 C<getEdgeList()>
-
-Gets the edgelist, which is a list of edges where each edge is defined as
-a pair of node indices.
-
-=head4 Returns
-
-An array ref with each element being a two-element array ref of the source
-and target node indices.
-
-=head4 Example Usage
-
-    my $edgelist = $parser->getEdgeList();
-    map { print join(" ", @$_), "\n"; } @$edgelist;
 
 
 =head3 C<getIndexSeqIdMap()>

--- a/lib/EFI/SSN/XgmmlReader/IdList.pm
+++ b/lib/EFI/SSN/XgmmlReader/IdList.pm
@@ -24,7 +24,7 @@ sub new {
     $self->{anno} = new EFI::Annotations;
     my ($attrNames, $attrDisplay) = $self->{anno}->get_expandable_attr();
     $self->{id_list_fields} = { map { $attrDisplay->{$_} => $_ } @$attrNames };
-    $self->{id_metadata} = {}; # any node metadata that we are to store (e.g. swissprot)
+    $self->{sequences} = {}; # any custom sequences to store
     $self->{meta_map} = undef; # Metanode -> IDs in metanode mapping
     $self->{id_type} = SEQ_UNIPROT;
 
@@ -71,26 +71,9 @@ sub getMetanodes {
 }
 
 
-sub getMetadata {
+sub getSequences {
     my $self = shift;
-    return $self->{id_metadata};
-}
-
-
-#
-# initializeNode - protected method
-#
-# Executes any code necessary to initialize internal node structures.
-#
-# Parameters:
-#    $seqId - sequence ID (e.g. the node label)
-#
-sub initializeNode {
-    my $self = shift;
-    my $seqId = shift;
-    # Initialize the list of sequences in the meta node (in the case that the network is a meta network).
-    # The meta node always includes itself
-    $self->{meta_map}->{$seqId}->{$seqId} = 1;
+    return $self->{sequences};
 }
 
 
@@ -134,12 +117,10 @@ sub processNodeAttribute {
 
         # Store the value in a hash ref in the case that the network is UniRef+RepNode
         # (in that case there will be duplicates because of the FIELD_REPNODE_IDS values)
-        $self->{meta_map}->{$seqId}->{$value} = 1;
-    # SwissProt
-    } elsif ($fieldName eq FIELD_SWISSPROT_DESC) {
-        $self->{id_metadata}->{$seqId}->{swissprot} = $value if $value;
+        $self->{meta_map}->{$seqId}->{$value} = undef;
+
     } elsif ($fieldName eq FIELD_SEQ_KEY) {
-        $self->{id_metadata}->{$seqId}->{sequence} = $value if $value;
+        $self->{sequences}->{$seqId} = $value if $value;
     }
 }
 
@@ -242,44 +223,6 @@ network then this hash is empty.
     my $metanodeMap = $parser->getMetanodes();
     foreach my $metanode (sort keys %$metanodeMap) {
         map { print join("\t", $metanode, $_), "\n"; } @{ $metanodeMap->{$metanode} };
-    }
-
-
-
-=head3 C<getMetadata()>
-
-Gets the metadata (node attributes) that is saved during parsing (currently only SwissProt
-description).  This is primarily used in the case that the network is UniProt; in that
-case the EFI database is not queried to obtain metadata information.  If the network is
-UniRef, then the database is queried and the SwissProt information from the queries is
-used instead of the saved node attribute.
-
-=head4 Returns
-
-A hash ref with keys being the sequence ID (metanode ID), with each value being another
-hash ref with each saved node attribute.  Currently the C<swissprot> and C<sequence> hash
-ref keys are supported.  Only sequence IDs with attribute values are in the hash ref.
-The C<sequence> key will only be present if a protein sequence was included; this is used
-when unidentified sequences are included in the analysis.
-
-    {
-        "UNIPROT_ID" => {
-            "swissprot" => "Description",
-            "sequence" => "ABC"
-        },
-        "UNIPROT_ID2" => {},
-        "UNIPROT_ID3" => {
-            "swissprot" => "Description"
-        }
-    }
-
-=head4 Example Usage
-
-    my $metadata = $parser->getMetadata();
-    foreach my $id (keys %$metadata) {
-        foreach my $md (keys %{ $metadata->{$id} }) {
-            print "$id\t$md\t$metadata->{$id}->{$md}\n";
-        }
     }
 
 =cut

--- a/lib/EFI/Xgmml/Writer.pm
+++ b/lib/EFI/Xgmml/Writer.pm
@@ -22,8 +22,6 @@ sub new {
     $self->{xmlns} = $args{xmlns} // DEFAULT_XMLNS;
     $self->{data_indent} = $args{data_indent} // 0;
     $self->{output_file} = $args{output_file};
-    $self->{mem_buffer_size} = 10 * 1024 * 1024;
-    $self->{mem_buffer} = "";
 
     return $self;
 }
@@ -40,48 +38,10 @@ sub open {
         flock($fh, LOCK_EX) or warn "Unable to obtain exclusive file lock on output SSN for writing: $!";
     };
 
-    # Pass $self into the writer, which will call print on the handle (see below)
-    my $writer = new XML::Writer(OUTPUT => $self, DATA_INDENT => $self->{data_indent}, UNSAFE => 1, PREFIX_MAP => '');
+    my $writer = new XML::Writer(OUTPUT => $fh, DATA_INDENT => $self->{data_indent}, UNSAFE => 1, PREFIX_MAP => '');
 
     $self->{writer} = $writer;
     $self->{output} = $fh;
-}
-
-
-#
-# print - private
-#
-# This method is used to interface XML::Writer with the string buffer.  XML::Writer calls 'print'
-# on the handle it was provided, meaning this function gets called.  Here we append the XML string
-# that XML::Writer passes to print() onto the string buffer.  Then, if it's greater than the max
-# buffer size, it gets written to the actual output buffer.
-#
-sub print {
-    my $self = shift;
-
-    $self->{mem_buffer} .= join('', @_);
-
-    if (length($self->{mem_buffer}) > $self->{mem_buffer_size}) {
-        $self->flushBuffer();
-    }
-}
-
-
-#
-# flushBuffer - private
-#
-# This method flushes the string buffer to the actual file handle.
-#
-sub flushBuffer {
-    my $self = shift;
-
-    if (length($self->{mem_buffer}) > 0) {
-        # Write the buffer to the file in one big chunk (to help with NFS latency)
-        $self->{output}->print($self->{mem_buffer});
-
-        # Erase the buffer for the next print call
-        $self->{mem_buffer} = "";
-    }
 }
 
 
@@ -90,7 +50,6 @@ sub close {
     my $self = shift;
 
     $self->{writer}->end(); # Finish writing XML tags
-    $self->flushBuffer(); # Save the buffer to the primary file handle
     $self->{output}->close(); # Close everything
 }
 

--- a/pipelines/gnt/color_gnt_xgmml.pl
+++ b/pipelines/gnt/color_gnt_xgmml.pl
@@ -4,6 +4,7 @@ use warnings;
 
 use Getopt::Long;
 use FindBin;
+use Time::HiRes qw(gettimeofday tv_interval);
 
 use lib "$FindBin::Bin/../../lib";
 
@@ -32,8 +33,13 @@ my ($clusterMapBySize, $clusterMapByNode) = parse_cluster_map_file($opts->{clust
 # Get the metanode data (mapping of repnode/UniRef to UniProt)
 my ($idType, $metanodeMap) = parse_metanode_map_file($opts->{metanode_map});
 
+my $timeGntStart = [gettimeofday];
+
 # Get the GNT data
 my $gntData = getGntData($opts->{gnd}, $idType, $metanodeMap);
+
+my $timeGntEnd = [gettimeofday];
+print "GND processing time: ", tv_interval($timeGntStart, $timeGntEnd), "\n";
 
 
 my $xwriter = new EFI::SSN::AttributeWriter(ssn => $opts->{ssn}, output_file => $opts->{color_gnt_ssn});
@@ -47,6 +53,8 @@ $xwriter->addAttributeHandler($gntHandler);
 
 $xwriter->write();
 
+my $timeSsnWriteFinished = [gettimeofday];
+print "SSN write time: ", tv_interval($timeGntEnd, $timeSsnWriteFinished), "\n";
 
 my $stats = $xwriter->getStats();
 my ($filename) = keys %$stats;

--- a/pipelines/shared/perl/compute_conv_ratio.pl
+++ b/pipelines/shared/perl/compute_conv_ratio.pl
@@ -2,8 +2,8 @@
 use strict;
 use warnings;
 
-use Getopt::Long;
 use FindBin;
+use Getopt::Long;
 
 use lib "$FindBin::Bin/../../../lib";
 
@@ -25,14 +25,14 @@ my ($clusterToId) = parse_cluster_map_file($opts->{cluster_map});
 # Get the metanode data (mapping of repnode/UniRef to UniProt)
 my ($idType, $sourceIdMap) = parse_metanode_map_file($opts->{seqid_source_map});
 
-# Get the edgelist
-my $edgelist = parseEdgelist($opts->{edgelist});
+# Get the node degrees from the edgelist
+my $nodeDegrees = computeNodeDegreesFromEdgelist($opts->{edgelist});
 
 # Get the mapping of node index to node sequence ID
 my $indexMap = parseIndexSeqidMap($opts->{index_seqid_map});
 
 # Compute degrees, metanode only
-my $degrees = computeDegrees($edgelist, $indexMap);
+my $degrees = computeDegrees($nodeDegrees, $indexMap);
 
 # Expand the metanodes
 my $fullClusterToId = resolve_mapping($clusterToId, $idType, $sourceIdMap);
@@ -129,25 +129,19 @@ sub computeConvRatio {
 # Compute the node degrees (the degree of connectivity of each node)
 #
 # Parameters:
-#    $edgelist - the edgelist that comes from parseEdgelist
+#    $nd - node degrees computed from the edgelist
 #    $indexMap - the mapping that comes from parseIndexSeqidMap
 #
 # Returns:
 #    hash ref of sequence ID to degree
 #
 sub computeDegrees {
-    my $edgelist = shift;
+    my $nd = shift;
     my $indexMap = shift;
 
-    my %nd;
-    foreach my $edge (@$edgelist) {
-        $nd{$edge->[0]}++;
-        $nd{$edge->[1]}++;
-    }
-
     my %degrees;
-    foreach my $idx (keys %nd) {
-        $degrees{$indexMap->{$idx}} = $nd{$idx};
+    foreach my $idx (keys %$nd) {
+        $degrees{$indexMap->{$idx}} = $nd->{$idx};
     }
 
     return \%degrees;
@@ -188,34 +182,34 @@ sub parseIndexSeqidMap {
 
 
 #
-# parseEdgeList
+# computeNodeDegreesFromEdgelist
 #
 # Read the edgelist file, where each line is an edge with the start and node indices
-# being the columns
+# being the columns and compute the degrees for each node index
 #
 # Parameters:
 #    $file - path to edgelist file
 #
 # Returns:
-#    array ref of edgelists, with each element being an array ref of start-end pairs
+#    hash ref of node degrees
 #
-sub parseEdgelist {
+sub computeNodeDegreesFromEdgelist {
     my $file = shift;
 
     open my $fh, "<", $file or die "Unable to open edgelist file '$file' for reading: $!";
 
-    my @edgelist;
-
+    my %nd;
     while (my $line = <$fh>) {
         chomp $line;
         next if not $line;
         my ($n1, $n2) = split(m/[\t ]/, $line);
-        push @edgelist, [$n1, $n2];
+        $nd{$n1}++;
+        $nd{$n2}++;
     }
 
     close $fh;
 
-    return \@edgelist;
+    return \%nd;
 }
 
 

--- a/pipelines/shared/perl/ssn_to_id_list.pl
+++ b/pipelines/shared/perl/ssn_to_id_list.pl
@@ -2,8 +2,8 @@
 use strict;
 use warnings;
 
-use Getopt::Long;
 use FindBin;
+use Getopt::Long;
 
 use lib "$FindBin::Bin/../../../lib";
 
@@ -22,10 +22,7 @@ my $opts = validateAndProcessOptions();
 
 my $parser = EFI::SSN::XgmmlReader::IdList->new(xgmml_file => $opts->{ssn});
 
-$parser->parse();
-
-my $edgelist = $parser->getEdgeList();
-saveEdgelist($edgelist, $opts->{edgelist});
+$parser->parse(edgelist_file => $opts->{edgelist});
 
 my $indexSeqIdMap = $parser->getIndexSeqIdMap();
 my $nodeSizeMap = $parser->getMetanodeSizes();
@@ -41,8 +38,8 @@ my $metanodeMap = $parser->getMetanodes();
 saveMetanodeMapping($opts->{seqid_source_map}, $metanodeMap, $metanodeType);
 
 if ($opts->{ssn_sequences}) {
-    my $metadata = $parser->getMetadata();
-    saveSsnSequences($opts->{ssn_sequences}, $metadata);
+    my $sequences = $parser->getSequences();
+    saveSsnSequences($opts->{ssn_sequences}, $sequences);
 }
 
 my $domainMap = $parser->getDomainIndexMap();
@@ -73,18 +70,16 @@ saveDomainMap($opts->{domain_id_map}, $domainMap);
 #
 # Parameters:
 #    $sequenceFile - path to the FASTA file to store sequences in
-#    $metadata - metadata hash ref that comes from EFI::SSN::XgmmlReader::IdList
+#    $sequences - metadata hash ref that comes from EFI::SSN::XgmmlReader::IdList
 #
 sub saveSsnSequences {
     my $sequenceFile = shift;
-    my $metadata = shift;
+    my $sequences = shift;
 
     open my $fh, ">", $sequenceFile or die "Unable to write to SSN sequence file '$sequenceFile': $!";
 
-    foreach my $id (keys %$metadata) {
-        if ($metadata->{$id}->{sequence}) {
-            $fh->print(format_sequence($id, $metadata->{$id}->{sequence}), "\n");
-        }
+    foreach my $id (keys %$sequences) {
+        $fh->print(format_sequence($id, $sequences->{$id}), "\n");
     }
 
     close $fh;
@@ -117,31 +112,6 @@ sub saveMetanodeMapping {
     }
 
     close $mmfh;
-}
-
-
-#
-# saveEdgelist
-#
-# Saves an edgelist to a file; the file has no header and takes the format of
-#     node1_index\tnode2_index
-#     ...
-#
-# Parameters:
-#    $edgelist - array ref of node indices for each edge
-#    $file - path to file to store edgelist in
-#
-sub saveEdgelist {
-    my $edgelist = shift;
-    my $file = shift;
-
-    open my $fh, ">", $file or die "Unable to write to edgelist file '$file': $!";
-
-    foreach my $edge (@$edgelist) {
-        $fh->print(join(" ", @$edge), "\n");
-    }
-
-    close $fh;
 }
 
 


### PR DESCRIPTION
This PR optimizes parts of the generatessn, clusteranalysis, neighborhoodconnectivity, colorssn, and gnt pipelines by the following:

* Undoing a change designed to mitigate issues arising from NFS (removing the string buffer code added in a previous branch)
* Avoiding storing edgelists in memory and instead writing directly to disk
* Flattens metadata structures when parsing SSNs