### PR TITLE
387 copy seq len node attributes for zz sequences

### DIFF
--- a/lib/EFI/Import/Source/Accession.pm
+++ b/lib/EFI/Import/Source/Accession.pm
@@ -7,7 +7,6 @@ use warnings;
 use Cwd qw(abs_path);
 use File::Basename qw(dirname);
 use lib dirname(abs_path(__FILE__)) . "/../../../"; # Import libs
-use lib dirname(abs_path(__FILE__)) . "/../../../../../../lib"; # Global libs
 use parent qw(EFI::Import::Source);
 
 use EFI::Annotations::Fields qw(:source :annotations);

--- a/lib/EFI/Import/Source/BLAST.pm
+++ b/lib/EFI/Import/Source/BLAST.pm
@@ -7,10 +7,9 @@ use warnings;
 use Cwd qw(abs_path);
 use File::Basename qw(dirname);
 use lib dirname(abs_path(__FILE__)) . "/../../../"; # Import libs
-use lib dirname(abs_path(__FILE__)) . "/../../../../../../lib"; # Global libs
 use parent qw(EFI::Import::Source);
 
-use EFI::Annotations::Fields ':source';
+use EFI::Annotations::Fields qw(FIELD_SEQ_LEN_KEY :source);
 
 
 our $TYPE_NAME = "blast";
@@ -106,7 +105,7 @@ sub makeMetadata {
     my $inputAttr = {
         &FIELD_SEQ_SRC_KEY => FIELD_SEQ_SRC_BLAST_INPUT,
         Description => "Input Sequence",
-        seq_len => length($querySeq),
+        &FIELD_SEQ_LEN_KEY => length($querySeq),
     };
 
     $destSeqData->addSequence(INPUT_SEQ_ID, $inputAttr);

--- a/lib/EFI/Import/Source/FASTA.pm
+++ b/lib/EFI/Import/Source/FASTA.pm
@@ -11,10 +11,9 @@ use Data::Dumper;
 use Cwd qw(abs_path);
 use File::Basename qw(dirname);
 use lib dirname(abs_path(__FILE__)) . "/../../../"; # Import libs
-use lib dirname(abs_path(__FILE__)) . "/../../../../../../../lib"; # Global libs
 use parent qw(EFI::Import::Source);
 
-use EFI::Annotations::Fields ':source';
+use EFI::Annotations::Fields qw(FIELD_SEQ_LEN_KEY :source);
 
 use EFI::Sequence::Type qw(make_unknown_sequence);
 use EFI::Util::FASTA::Headers;
@@ -229,7 +228,10 @@ sub makeMetadata {
     my $destSeqData = shift;
 
     foreach my $id (keys %$seq) {
-        my $attr = { &FIELD_SEQ_SRC_KEY => FIELD_SEQ_SRC_VALUE_FASTA };
+        my $attr = {
+            &FIELD_SEQ_SRC_KEY => FIELD_SEQ_SRC_VALUE_FASTA,
+            &FIELD_SEQ_LEN_KEY => length($seq->{$id}),
+        };
         foreach my $metaKey (keys %{ $seqMeta->{$id} }) {
             $attr->{$metaKey} = $seqMeta->{$id}->{$metaKey};
         }

--- a/lib/EFI/Import/Source/Family.pm
+++ b/lib/EFI/Import/Source/Family.pm
@@ -7,7 +7,6 @@ use strict;
 use Cwd qw(abs_path);
 use File::Basename qw(dirname);
 use lib dirname(abs_path(__FILE__)) . "/../../../";
-use lib dirname(abs_path(__FILE__)) . "/../../../../../../../lib"; # Global libs
 use parent qw(EFI::Import::Source);
 
 use EFI::Annotations::Fields qw(:source :annotations);

--- a/lib/EFI/SSN/XgmmlWriter.pm
+++ b/lib/EFI/SSN/XgmmlWriter.pm
@@ -351,7 +351,14 @@ sub makeNodeAttributes {
         next if $field eq FIELD_SEQ_KEY;
 
         my $value = $self->{metadata}->getSequence($uniprotId)->getAttribute($field, 1);
-        $value = MISSING_VALUE if not $value;
+        # Ensure that the XGMML get a number if the value is not defined or is not a number --
+        # otherwise Cytoscape crashes
+        if ($fields->{$field}->{type} eq "integer" and (not defined $value or not looks_like_number($value))) {
+            $value = 0;
+        } elsif (not defined $value) {
+            $value = MISSING_VALUE;
+        }
+
         $source = $value if $field eq FIELD_SEQ_SRC_KEY;
 
         # If the value is an array, and is only one, then save it as a scalar because we only want

--- a/lib/EFI/SSN/XgmmlWriter.pm
+++ b/lib/EFI/SSN/XgmmlWriter.pm
@@ -353,7 +353,7 @@ sub makeNodeAttributes {
         my $value = $self->{metadata}->getSequence($uniprotId)->getAttribute($field, 1);
         # Ensure that the XGMML get a number if the value is not defined or is not a number --
         # otherwise Cytoscape crashes
-        if ($fields->{$field}->{type} eq "integer" and (not defined $value or not looks_like_number($value))) {
+        if ($fields->{$field}->{type} eq "integer" and not defined $value) {
             $value = 0;
         } elsif (not defined $value) {
             $value = MISSING_VALUE;

--- a/lib/EFI/Sequence.pm
+++ b/lib/EFI/Sequence.pm
@@ -67,6 +67,12 @@ sub getAttributeNames {
 }
 
 
+sub getAllAttributes {
+    my $self = shift;
+    return $self->{attr};
+}
+
+
 # public
 sub setAttribute {
     my $self = shift;

--- a/pipelines/generatessn/annotations/get_annotations.pl
+++ b/pipelines/generatessn/annotations/get_annotations.pl
@@ -95,6 +95,10 @@ my %unirefClusterIdSeqLen;
 foreach my $accession (sort @$accessions){
     if (is_unknown_sequence($accession)) {
         my $data = formatAnnoData($accession, [], [], {}, {});
+        my $attributes = $inputIds->getSequence($accession)->getAllAttributes();
+        foreach my $attr (keys %$attributes) {
+            $data->{$attr} = $attributes->{$attr};
+        }
         $outputIds->addSequence($accession, $data);
         next;
     }
@@ -196,7 +200,7 @@ sub formatAnnoData {
 
         # If the field doesn't exist in the database attributes but exists in the existing metadata
         # then use the existing value
-        } elsif (not $data->{$field}) {
+        } elsif (not exists $data->{$field}) {
             my $value = $inputIds->getSequence($accession)->getAttribute($field, 1);
             $data->{$field} = $value;
         }


### PR DESCRIPTION
This PR contains changes that address issues with SSNs:

1. Sequence lengths are now included for FASTA jobs
2. BLAST job input sequence length is now included
3. Validation now occurs to ensure that non-integer values never get saved into an integer field (Cytoscape crashes when that occurs)