### PR TITLE
Save cluster ID instead of number to cluster_size.txt

### DIFF
--- a/pipelines/shared/perl/get_id_lists.pl
+++ b/pipelines/shared/perl/get_id_lists.pl
@@ -121,10 +121,12 @@ sub saveClusterSizes {
         # (e.g. an older network is being used).  In this case, skip the cluster.
         next if not $clusterToId->{$cnum};
 
+        my $clusterId = "Cluster_${cnum}";
+
         my $uniprotSize = @{ $clusterToId->{$cnum} };
         my $uniref90Size = @{ $unirefMap->{uniref90}->{$cnum} // [] } if $unirefMap->{uniref90};
         my $uniref50Size = @{ $unirefMap->{uniref50}->{$cnum} // [] } if $unirefMap->{uniref50};
-        my @row = ($cnum, $uniprotSize);
+        my @row = ($clusterId, $uniprotSize);
         push @row, $uniref90Size if $uniref90Size;
         push @row, $uniref50Size if $uniref50Size;
 


### PR DESCRIPTION
This PR fixes a naming issue in `cluster_size.txt`, an output of the color SSN subworkflow.  The previous value stored in the first column was just the number of the column.  All of the output files (e.g. ID lists, weblogos, HMMs) are all named based on the cluster ID, which is simply the cluster number prefixed with `Cluster_` (e.g. `Cluster_42`).  This file is used by the front end as a master mapping file for determining which weblogos, HMMs, etc to display, and the front end currently has to construct the ID.  It is best that the ID format/construction occur in this repository.