### PR TITLE
395 - Muscle process block configuration

### DIFF
--- a/conf/docker.config
+++ b/conf/docker.config
@@ -55,6 +55,7 @@ process {
 
     withLabel: muscle_align {
         cpus = 1
+        time = 24.hr
     }
 }
 

--- a/conf/pbspro.config
+++ b/conf/pbspro.config
@@ -99,6 +99,8 @@ process {
         executor = 'pbspro'
         queue = 'normal'
         cpus = 1
+        memory = convertResourceAllocation(1)
+        time = 24.hr
     }
 }
 

--- a/conf/pbstorque.config
+++ b/conf/pbstorque.config
@@ -111,6 +111,9 @@ process {
         executor = 'pbs'
         queue = 'normal'
         cpus = 1
+        memory = convertResourceAllocation(1)
+        time = 24.hr
+        clusterOptions = "-l walltime=24:00:00"
     }
 }
 

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -56,6 +56,7 @@ process {
 
     withLabel: muscle_align {
         cpus = 1
+        time = 24.hr
     }
 }
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -99,6 +99,8 @@ process {
         executor = 'slurm'
         queue = 'efi'
         cpus = 1
+        memory = convertResourceAllocation(1)
+        time = 24.hr
     }
 }
 

--- a/pipelines/clusteranalysis/subworkflows/msa.nf
+++ b/pipelines/clusteranalysis/subworkflows/msa.nf
@@ -27,8 +27,8 @@ process muscle3_align {
     publishDir "${params.final_output_dir}/data/msa/${seq_type}", mode: "copy", pattern: "*.afa"
 
     // MUSCLE can crash due to out of memory errors; it also might run for extended time
-    // for especially large sequence sets. Set the max time this process block can run in
-    // the config file. If a process runs beyond this time error, a timeout error is thrown.
+    // especially for large sequence sets. Set the max time this process block can run in
+    // the config file. If a process runs beyond this time, a timeout error is thrown.
     // Ignore these failures, skip the cluster being analyzed, and proceed with
     // the other clusters. Any other errors should cause a terminate message to nextflow.
     errorStrategy {
@@ -43,6 +43,7 @@ process muscle3_align {
 
     script:
     """
+    # -maxhours h  -- Maximum time. If h hours have elpased, then complete the current iteration and stop. Default no time limit.
     muscle3 -in ${fasta} -out ${id}.afa -maxhours ${task.time.toHours() - 2}
     """
 }

--- a/pipelines/clusteranalysis/subworkflows/msa.nf
+++ b/pipelines/clusteranalysis/subworkflows/msa.nf
@@ -26,14 +26,14 @@ process muscle3_align {
     label "muscle_align"
     publishDir "${params.final_output_dir}/data/msa/${seq_type}", mode: "copy", pattern: "*.afa"
 
-    // MUSCLE can crash due to out of memory errors, or invalid data.  If we crash due to OOM,
-    // retry twice with larger amounts of RAM.  Otherwise, ignore the failure and proceed with
-    // the other clusters.
-    memory { 2.GB * task.attempt }
-    maxRetries 2
+    // MUSCLE can crash due to out of memory errors; it also might run for extended time
+    // for especially large sequence sets. Set the max time this process block can run in
+    // the config file. If a process runs beyond this time error, a timeout error is thrown.
+    // Ignore these failures, skip the cluster being analyzed, and proceed with
+    // the other clusters. Any other errors should cause a terminate message to nextflow.
     errorStrategy {
         // 137 == OOM, 140 == timeout
-        task.exitStatus in [137, 140] ? 'retry' : 'ignore'
+        task.exitStatus in [137, 140] ? 'ignore' : 'terminate'
     }
 
     input:
@@ -43,7 +43,7 @@ process muscle3_align {
 
     script:
     """
-    muscle3 -in ${fasta} -out ${id}.afa
+    muscle3 -in ${fasta} -out ${id}.afa -maxhours ${task.time.toHours() - 2}
     """
 }
 


### PR DESCRIPTION
- [x] Fix errorStrategy for muscle3_process block.
- [x] Configure the muscle process blocks to hard-set the maxtime to limit how long these process types can run. 
- [x] Unfortunately, no control for RAM usage is possible but still implemented a maximum for allocated RAM too.

Closes #395 