### PR TITLE
396 - Add label to the GNTGNN generation process block

### DIFF
--- a/pipelines/gnt/gnt.nf
+++ b/pipelines/gnt/gnt.nf
@@ -6,6 +6,8 @@ cluster_data_dir = "cluster-data"
 
 
 process create_gnns {
+    label 'TASK_create_ssn'
+
     publishDir params.final_output_dir, mode: "copy", pattern: "{hub_count.txt,cooc_table.txt,nomatches_noneighbors.txt,gnd.sqlite,*.zip}"
 
     input:


### PR DESCRIPTION
Handle GNN creation process block similar as the SSN creation process block. Control for large required memory allocation and potentially large IO amount.  