### PR TITLE
349 compute cr for uniref in cr utility

### DIFF
--- a/pipelines/convergenceratio/convergenceratio.nf
+++ b/pipelines/convergenceratio/convergenceratio.nf
@@ -1,7 +1,7 @@
 
 include { all_by_all_blast; blastreduce; blastreduce_transcode_fasta; condense_redundant; create_blast_db; restore_condensed; sort_and_split_fasta } from "../shared/nextflow/blast.nf"
 include { unzip_ssn } from "../shared/nextflow/util.nf"
-include { compute_clusters; get_conv_ratio_table; get_id_list; get_ssn_id_info } from "../shared/nextflow/color_workflow.nf"
+include { compute_clusters; get_id_list; get_ssn_id_info } from "../shared/nextflow/color_workflow.nf"
 
 process compute_blast_conv_ratio {
     input:
@@ -56,25 +56,45 @@ process get_fasta_files {
     """
 }
 
-process get_selected_id_lists {
+process compute_ssn_conv_ratio {
     input:
-        path uniprot_dir
-        path uniref90_dir
-        path uniref50_dir
-
+        path edgelist
+        path index_seqid_map
+        path cluster_id_map
+        path seqid_source_map
     output:
-        path "selected_ids/*.txt", emit: "id_files"
+        path "conv_ratio.txt", emit: conv_ratio
 
     script:
     """
-    mkdir -p selected_ids
+    perl $projectDir/../shared/perl/compute_conv_ratio.pl \
+        --cluster-map $cluster_id_map \
+        --index-seqid-map $index_seqid_map \
+        --edgelist $edgelist \
+        --seqid-source-map $seqid_source_map \
+        --conv-ratio conv_ratio.txt \
+        --use-metanodes
+    """
+}
 
-    if ls ${uniref50_dir}/*.txt 1> /dev/null 2>&1; then
-        cp ${uniref50_dir}/*.txt selected_ids/
-    elif ls ${uniref90_dir}/*.txt 1> /dev/null 2>&1; then
-        cp ${uniref90_dir}/*.txt selected_ids/
+process count_fasta {
+    tag "ca_count_fasta_${id}"
+
+    input:
+        tuple val(id), path(fasta)
+
+    output:
+        // We emit the same tuple structure so it can mix back easily later, and add the number
+        // of sequences in the input file to the tuple
+        tuple val(id), path(fasta), env(COUNT)
+
+    script:
+
+    """
+    if [ -s "${fasta}" ]; then
+        COUNT=\$(grep -c "^>" ${fasta})
     else
-        cp ${uniprot_dir}/*.txt selected_ids/
+        COUNT=0
     fi
     """
 }
@@ -99,15 +119,13 @@ workflow {
 
     id_list_data = get_id_list(compute_info.cluster_id_map, compute_info.singletons, ssn_data.seqid_source_map, sequence_type_val)
 
-    // Get the ID lists that will be used, e.g. the original sequences from the SSN
-    input_seq_type_id_lists = get_selected_id_lists(id_list_data.uniprot_dir, id_list_data.uniref90_dir, id_list_data.uniref50_dir)
-
     //
     // STEP 2: OBTAIN THE FASTA FILES
     //
 
     // Get the cluster IDs from the file names
-    cluster_id_lists = input_seq_type_id_lists 
+    cluster_id_lists = id_list_data.uniprot_tuples
+            .map { id_type, file -> file }
             .flatten()
             .filter { file -> !file.name.contains("_All") }          // Don"t include the file with all sequences in the analysis
             .filter { file -> !file.name.contains("singleton") }     // Don"t include singletons in the analysis
@@ -119,7 +137,18 @@ workflow {
             }
 
     // Get FASTA files; the return value is a channel of tuples of [clusterId, file]
-    cluster_fasta = get_fasta_files(cluster_id_lists)
+    all_fasta_files = get_fasta_files(cluster_id_lists)
+
+    // Because some sequences may be removed from future databases, we need to count how many
+    // sequences were retrieved and ensure we're only doing BLAST for clusters that have at least
+    // one sequence
+    counted_fasta = count_fasta(all_fasta_files)
+    counted_fasta.branch {
+        valid: it[2].toInteger() >= 1
+        ignored: true
+    }.set { complete_fasta }
+
+    cluster_fasta = complete_fasta.valid.map { id, file, size -> tuple(id, file) }
 
     //
     // STEP 3: RUN THE EST-BASED ALL-BY-ALL WORKFLOW
@@ -149,7 +178,7 @@ workflow {
     //
 
     // Compute the convergence ratio based on the edges and nodes in each cluster
-    cr_table = get_conv_ratio_table(ssn_data.edgelist, ssn_data.index_seqid_map, compute_info.cluster_id_map, ssn_data.seqid_source_map)
+    cr_table = compute_ssn_conv_ratio(ssn_data.edgelist, ssn_data.index_seqid_map, compute_info.cluster_id_map, ssn_data.seqid_source_map)
 
     // Compute the convergence ratio based on the BLAST results
     //stats_files = compute_blast_conv_ratio(blast_parquet.combine(fasta_lengths_parquet, by: 0))

--- a/pipelines/convergenceratio/convergenceratio.nf
+++ b/pipelines/convergenceratio/convergenceratio.nf
@@ -6,7 +6,6 @@ include { compute_clusters; get_id_list; get_ssn_id_info } from "../shared/nextf
 process compute_blast_conv_ratio {
     input:
         tuple val(cluster_id), path(blast_parquet), path(fasta_file)
-
     output:
         path("${cluster_id}_conv_ratio.json")
 
@@ -25,7 +24,6 @@ process merge_conv_ratios {
     input:
         path stats_files
         path cr_table
-
     output:
         path "conv_ratio.tab", emit: "conv_ratio"
         path "stats.json", emit: "stats"
@@ -43,7 +41,6 @@ process merge_conv_ratios {
 process get_fasta_files {
     input:
         tuple val(cluster_id), path(id_file)
-
     output:
         tuple val(cluster_id), path("*.fasta", arity: "1")
 
@@ -78,14 +75,10 @@ process compute_ssn_conv_ratio {
 }
 
 process count_fasta {
-    tag "ca_count_fasta_${id}"
-
     input:
         tuple val(id), path(fasta)
-
     output:
-        // We emit the same tuple structure so it can mix back easily later, and add the number
-        // of sequences in the input file to the tuple
+        // We add the number of sequences in the input file to the tuple
         tuple val(id), path(fasta), env(COUNT)
 
     script:

--- a/pipelines/convergenceratio/statistics/merge_conv_ratios.py
+++ b/pipelines/convergenceratio/statistics/merge_conv_ratios.py
@@ -21,7 +21,7 @@ def check_args(args: argparse.Namespace) -> argparse.Namespace:
         exit(1)
     return args
 
-def load_blast_conv_files(input_files: List) -> Dict[str, Dict[str, str]]:
+def load_blast_conv_files(input_files: List) -> Dict[int, Dict[str, str]]:
     """
     Load the BLAST-based convergence ratios from the given files.
 
@@ -42,7 +42,7 @@ def load_blast_conv_files(input_files: List) -> Dict[str, Dict[str, str]]:
         # Extract the cluster number
         match = re.search(r'Cluster_(\d+)_conv_ratio\.json', filename)
         if match:
-            cluster_id = match.group(1)
+            cluster_num = int(match.group(1))
         else:
             # Terminate because something bad happened, if the files aren't in the specified format
             raise Exception(f"Invalid filename format '{filename}'")
@@ -63,7 +63,7 @@ def load_blast_conv_files(input_files: List) -> Dict[str, Dict[str, str]]:
         except Exception as e:
             print(f"Error processing file {json_file}: {e}", file=sys.stderr)
 
-        blast_data[cluster_id] = {
+        blast_data[cluster_num] = {
             'ratio': conv_ratio,
             'edges': edges,
             'nodes': nodes
@@ -71,7 +71,7 @@ def load_blast_conv_files(input_files: List) -> Dict[str, Dict[str, str]]:
 
     return blast_data
 
-def load_ssn_conv_data(data_file: str) -> Dict[str, Dict[str, str]]:
+def load_ssn_conv_data(data_file: str) -> Dict[int, Dict[str, str]]:
     """
     Load the convergence ratio data from the SSN-based table.
 
@@ -92,7 +92,7 @@ def load_ssn_conv_data(data_file: str) -> Dict[str, Dict[str, str]]:
 
             for line in fh:
                 cluster_num, conv_ratio, num_nodes, num_ids, num_edges = re.split(r'\t', line.strip())
-                ssn_data[cluster_num] = {
+                ssn_data[int(cluster_num)] = {
                     'ratio': conv_ratio,
                     'edges': num_edges,
                     'nodes': num_nodes,
@@ -104,7 +104,7 @@ def load_ssn_conv_data(data_file: str) -> Dict[str, Dict[str, str]]:
 
     return ssn_data
 
-def calc_sig_figs(blast_conv_data: Dict[Any, Any]) -> int:
+def calc_sig_figs(blast_conv_data: Dict[int, Any]) -> int:
     """
     Compute the number of significant figures that are used for formatting.
 
@@ -134,7 +134,7 @@ def calc_sig_figs(blast_conv_data: Dict[Any, Any]) -> int:
 
     return digits
 
-def save_merged_data(output: str, blast_conv_data: Dict[Any, Any], ssn_conv_data: Dict[Any, Any], digits: int):
+def save_merged_data(output: str, blast_conv_data: Dict[int, Any], ssn_conv_data: Dict[int, Any], digits: int):
     """
     Merge the individual convergence ratio data into one file.
 
@@ -155,16 +155,16 @@ def save_merged_data(output: str, blast_conv_data: Dict[Any, Any], ssn_conv_data
             f_out.write("\t".join(["Cluster Number", "Convergence Ratio", "Number of IDs", "Number of BLAST Matches", "SSN Cluster Convergence Ratio", "Number of Nodes", "Number of Edges"]) + "\n")
 
             # Iterate through the dictionary and write the formatted rows
-            for cluster_id, metrics in blast_conv_data.items():
+            for cluster_num, metrics in sorted(blast_conv_data.items()):
                 blast_conv_ratio = metrics['ratio']
                 blast_conv_ratio_fmt = f"{blast_conv_ratio:.{digits}e}" if isinstance(blast_conv_ratio, float) else str(blast_conv_ratio)
 
-                ssn_metrics = ssn_conv_data.get(cluster_id)
+                ssn_metrics = ssn_conv_data.get(cluster_num)
                 ssn_conv_ratio = ssn_metrics['ratio']
                 ssn_conv_ratio_fmt = f"{ssn_conv_ratio:.{digits}e}" if isinstance(ssn_conv_ratio, float) else str(ssn_conv_ratio)
 
                 # Write all four columns separated by tabs
-                f_out.write("\t".join([cluster_id, blast_conv_ratio_fmt, str(metrics['nodes']), str(metrics['edges']), ssn_conv_ratio_fmt, str(ssn_metrics['nodes']), str(ssn_metrics['edges'])]) + "\n")
+                f_out.write("\t".join([str(cluster_num), blast_conv_ratio_fmt, str(metrics['nodes']), str(metrics['edges']), ssn_conv_ratio_fmt, str(ssn_metrics['nodes']), str(ssn_metrics['edges'])]) + "\n")
 
     except KeyError as e:
         print(f"Unable to find cluster ID {e.args[0]} in SSN convergence ratio data", file=sys.stderr)

--- a/pipelines/shared/perl/compute_conv_ratio.pl
+++ b/pipelines/shared/perl/compute_conv_ratio.pl
@@ -34,6 +34,7 @@ my $indexMap = parseIndexSeqidMap($opts->{index_seqid_map});
 # Compute degrees, metanode only
 my $degrees = computeDegrees($nodeDegrees, $indexMap);
 
+# Expand the metanodes
 my $fullNetworkIds = resolve_mapping($clusterToId, $idType, $sourceIdMap);
 
 my $convRatios = computeConvRatio($clusterToId, $fullNetworkIds, $degrees, $opts->{use_metanodes});

--- a/pipelines/shared/perl/compute_conv_ratio.pl
+++ b/pipelines/shared/perl/compute_conv_ratio.pl
@@ -34,10 +34,9 @@ my $indexMap = parseIndexSeqidMap($opts->{index_seqid_map});
 # Compute degrees, metanode only
 my $degrees = computeDegrees($nodeDegrees, $indexMap);
 
-# Expand the metanodes
-my $fullClusterToId = resolve_mapping($clusterToId, $idType, $sourceIdMap);
+my $fullNetworkIds = resolve_mapping($clusterToId, $idType, $sourceIdMap);
 
-my $convRatios = computeConvRatio($clusterToId, $fullClusterToId, $degrees);
+my $convRatios = computeConvRatio($clusterToId, $fullNetworkIds, $degrees, $opts->{use_metanodes});
 
 saveConvRatioData($opts->{conv_ratio}, $convRatios);
 
@@ -88,6 +87,7 @@ sub saveConvRatioData {
 #    $clusterToId - mapping of cluster to SSN nodes (e.g. metanodes/IDs)
 #    $fullClusterToId - mapping of cluster to sequences (expanded from metanodes, if relevant)
 #    $degrees - node degree hash ref
+#    $useMetanodes - true to use metanodes for the computation rather than full expanded UniProt IDs
 #
 # Returns:
 #    array ref of data rows
@@ -96,6 +96,7 @@ sub computeConvRatio {
     my $clusterToId = shift;
     my $fullClusterToId = shift;
     my $degrees = shift;
+    my $useMetanodes = shift || 0;
 
     # cluster to conv ratio
     my @data;
@@ -106,13 +107,14 @@ sub computeConvRatio {
         my $numNodes = @{ $clusterToId->{$cnum} };
         my $numIds = @fullIds;
 
+        my @clusterIds = $useMetanodes ? @{ $clusterToId->{$cnum} } : @{ $fullClusterToId->{$cnum} };
         my $numDegree = 0;
-        foreach my $id (@fullIds) {
+        foreach my $id (@clusterIds) {
             next if not $degrees->{$id};
             $numDegree += $degrees->{$id};
         }
 
-        my $denom = $numIds * ($numIds - 1);
+        my $denom = $useMetanodes ? $numNodes * ($numNodes - 1) : $numIds * ($numIds - 1);
         my $convRatio = 0;
         $convRatio = $numDegree / $denom if $denom > 0;
         $convRatio = sprintf("%.2e", $convRatio);
@@ -222,6 +224,7 @@ sub validateAndProcessOptions {
     $optParser->addOption("edgelist=s", 1, "path to a file with the edgelist", OPT_FILE);
     $optParser->addOption("conv-ratio=s", 1, "path to an output file to save convergence ratios", OPT_FILE);
     $optParser->addOption("seqid-source-map=s", 0, "path to a file mapping repnode or UniRef IDs in the SSN to sequence IDs within the repnode or UniRef ID cluster (optional)", OPT_FILE);
+    $optParser->addOption("use-metanodes", 0, "use metanodes (e.g. SSN/UniRef nodes) to compute convergence ratio; otherwise use the full UniProt set of sequences in the cluster");
 
     if (not $optParser->parseOptions() or $optParser->wantHelp()) {
         print $optParser->printHelp();
@@ -275,6 +278,12 @@ Path to an output file to store the convergence ratios in
 Optional path to a file that maps metanodes (e.g. RepNodes or UniRef IDs) that are in the SSN
 to sequence IDs that are within the metanode. If present the convergence ratio is calculated
 by taking into account the full cluster size.
+
+=item C<--use-metanodes>
+
+If the input is an UniRef SSN and this flag is provided, then metanodes (e.g. SSN nodes) are used
+to compute the convergence ratio.  Otherwise the UniProt sequences in the cluster are used.  If
+the input is UniProt, then the number of sequences are equivalent to the number of nodes.
 
 =back
 


### PR DESCRIPTION
This PR fixes issues in the convergence ratio pipeline.  Previously, the "SSN convergence ratio" value that was reported was the same value computed by the color SSN, which always based on the UniRef nodes (e.g. UniRef clusters are expanded).  However, in the legacy code for the convergence ratio utility, this ratio is computed based on the number of metanode edges for UniRef inputs.  A flag was added that conditionally enabled computation based on metanode rather than UniProt sequences, for the convergence ratio pipeline.  The color SSN pipeline retains the same functionality.  Additionally, due to the UniProt database changes, some clusters may end up having no sequences identified when retrieving FASTA.  The updates to the code ensure that these clusters are excluded from the computation.  Finally, in the python code for computing convergence ratio, proper sorting was implemented as was support for cluster IDs (e.g. `Cluster_1` rather than the previous numeric value of `1`).