### PR TITLE
394 analysis filtering not properly applied

### DIFF
--- a/lib/EFI/Import/Config/Filter.pm
+++ b/lib/EFI/Import/Config/Filter.pm
@@ -76,8 +76,8 @@ sub validateOptions {
     $opts->{fraction} = ($filter->{fraction} and $filter->{fraction} =~ m/^\d+$/) ? $filter->{fraction} : 1;
     $opts->{remove_fragments} = exists $filter->{fragments} ? 1 : 0;
     $opts->{family_filter} = $filter->{family};
-    $opts->{min_seq_length} = ($filter->{min_seq_length} and $filter->{min_seq_length} =~ m/^\d+$/) ? $filter->{min_seq_length} : DEFAULT_MIN_SEQ_LENGTH;
-    $opts->{max_seq_length} = ($filter->{max_seq_length} and $filter->{max_seq_length} =~ m/^\d+$/) ? $filter->{max_seq_length} : DEFAULT_MAX_SEQ_LENGTH;
+    $opts->{min_seq_length} = ($filter->{"min-seq-length"} and $filter->{"min-seq-length"} =~ m/^\d+$/) ? $filter->{"min-seq-length"} : DEFAULT_MIN_SEQ_LENGTH;
+    $opts->{max_seq_length} = ($filter->{"max-seq-length"} and $filter->{"max-seq-length"} =~ m/^\d+$/) ? $filter->{"max-seq-length"} : DEFAULT_MAX_SEQ_LENGTH;
     my @taxFilterErrors = $self->parseTaxonomyFilterOptions($filter, $opts);
     push @errors, @taxFilterErrors;
 

--- a/lib/EFI/Import/Filter/ExplicitIds.pm
+++ b/lib/EFI/Import/Filter/ExplicitIds.pm
@@ -46,7 +46,11 @@ sub applyFilter {
 
     my $explicitIds = $self->parseIdList();
 
-    my @ids = $seqs->getAllSequenceIds();
+    # For this filter we only remove the primary IDs (e.g. if the input is UniRef50, then only
+    # filter out the UniRef50 IDs, not children).  This filter is only useful for the sequences
+    # that were used in the EST computation, for applying a length filter to those sequences
+    # when performing SSN filtering.
+    my @ids = $seqs->getSequenceIds();
 
     my $numRemoved = 0;
     foreach my $id (@ids) {

--- a/lib/EFI/Sequence/Collection.pm
+++ b/lib/EFI/Sequence/Collection.pm
@@ -303,8 +303,6 @@ sub updateUnirefMetadata {
     foreach my $unirefId (keys %uniprotIds) {
         my @ids = sort @{ $uniprotIds{$unirefId} };
         my $size = @ids;
-        print "Setting metadata for $unirefId:\n";
-        print "\t", join(",", @ids), " $size\n";
         $self->{seq}->{$unirefId}->setAttribute($attrName, \@ids);
         $self->{seq}->{$unirefId}->setAttribute($sizeAttrName, $size);
     }

--- a/lib/EFI/Sequence/Collection.pm
+++ b/lib/EFI/Sequence/Collection.pm
@@ -108,33 +108,44 @@ sub removeSequence {
     # Now remove from the accession ID table.  Primary sequence type refers to the sequence
     # type of the sequence version (e.g. UniProt, UniRef)
 
-    # If the primary sequence type is UniRef50 and this ID is a UniRef50 ID then delete all
-    # UniRef90 and UniProt IDs that are in that UniRef50 cluster
-    if ($self->{sequence_version} eq SEQ_UNIREF50 and $self->{uniref50}->{$sequenceId}) {
+    # If this ID is a UniRef50 ID then delete all UniRef90 and UniProt IDs that are in that
+    # UniRef50 cluster
+    if ($self->{uniref50}->{$sequenceId}) {
         foreach my $ur90 (keys %{ $self->{uniref50}->{$sequenceId} }) {
             if ($self->{uniref90}->{$ur90}) {
                 foreach my $up (keys %{ $self->{uniref90}->{$ur90} }) {
                     delete $self->{uniprot}->{$up};
+                    delete $self->{seq}->{$up} if $self->{seq}->{$up};
                 }
             } else {
                 delete $self->{uniprot}->{$ur90};
+                delete $self->{seq}->{$ur90} if $self->{seq}->{$ur90};
             }
             delete $self->{uniref90}->{$ur90};
         }
         delete $self->{uniref50}->{$sequenceId};
     }
-    
-    # If the primary sequence type is UniRef90 and this ID is a UniRef90 ID then delete all
-    # UniProt IDs that are in that UniRef90 cluster
-    if ($self->{sequence_version} eq SEQ_UNIREF90 and $self->{uniref90}->{$sequenceId}) {
+
+    # If this ID is a UniRef90 ID then delete all UniProt IDs that are in that UniRef90 cluster
+    elsif ($self->{uniref90}->{$sequenceId}) {
+        my $parentUniref50 = $self->{uniprot}->{$sequenceId}->[1];
         foreach my $up (keys %{ $self->{uniref90}->{$sequenceId} }) {
             delete $self->{uniprot}->{$up};
+            delete $self->{seq}->{$up} if $self->{seq}->{$up};
         }
         delete $self->{uniref90}->{$sequenceId};
+        # Remove from the parent UniRef50 cluster if it exists
+        delete $self->{uniref50}->{$parentUniref50}->{$sequenceId} if $parentUniref50 and exists $self->{uniref50}->{$parentUniref50}->{$sequenceId};
     }
 
     # Remove the UniProt regardless of primary sequence type
-    if ($self->{uniprot}->{$sequenceId}) {
+    else {
+        my $parentUniref50 = $self->{uniprot}->{$sequenceId}->[1];
+        my $parentUniref90 = $self->{uniprot}->{$sequenceId}->[0];
+        # Remove from the parent UniRef90 cluster if it exists
+        delete $self->{uniref90}->{$parentUniref90}->{$sequenceId} if $parentUniref90 and exists $self->{uniref90}->{$parentUniref90}->{$sequenceId};
+        # Remove from the parent UniRef50 cluster if it exists
+        delete $self->{uniref50}->{$parentUniref50}->{$sequenceId} if $parentUniref50 and exists $self->{uniref50}->{$parentUniref50}->{$sequenceId};
         delete $self->{uniprot}->{$sequenceId};
     }
 }
@@ -149,7 +160,7 @@ sub mergeSequences {
     my $mergedSeq = $self->getSequence($targetId);
 
     my %mergedAttrs;
-    map { push @{ $mergedAttrs{$_} }, $mergedSeq->getAttribute($_, 1); } $mergedSeq->getAttributeNames();
+    push @{ $mergedAttrs{$_} }, $mergedSeq->getAttribute($_, 1) for $mergedSeq->getAttributeNames();
 
     foreach my $id (@mergedIds) {
         my $seq = $self->getSequence($id);
@@ -286,13 +297,14 @@ sub updateUnirefMetadata {
             }
         }
     }
-    
 
     my $attrName = $self->{sequence_version} eq SEQ_UNIREF90 ? FIELD_UNIREF90_IDS : FIELD_UNIREF50_IDS;
     my $sizeAttrName = $self->{sequence_version} eq SEQ_UNIREF90 ? FIELD_UNIREF90_CLUSTER_SIZE : FIELD_UNIREF50_CLUSTER_SIZE;
     foreach my $unirefId (keys %uniprotIds) {
         my @ids = sort @{ $uniprotIds{$unirefId} };
         my $size = @ids;
+        print "Setting metadata for $unirefId:\n";
+        print "\t", join(",", @ids), " $size\n";
         $self->{seq}->{$unirefId}->setAttribute($attrName, \@ids);
         $self->{seq}->{$unirefId}->setAttribute($sizeAttrName, $size);
     }
@@ -365,6 +377,17 @@ sub loadMetadataFile {
 
     foreach my $id (keys %data) {
         $self->addSequence($id, $data{$id});
+    }
+
+    # If the version is 'auto', then check for UniRef cluster ID fields to determine the version
+    if ($self->{sequence_version} eq SEQ_AUTO) {
+        if (exists $fields{&FIELD_UNIREF90_IDS}) {
+            $self->{sequence_version} = SEQ_UNIREF90;
+        } elsif (exists $fields{&FIELD_UNIREF50_IDS}) {
+            $self->{sequence_version} = SEQ_UNIREF50;
+        } else {
+            $self->{sequence_version} = SEQ_UNIPROT;
+        }
     }
 
     return 1;
@@ -468,7 +491,7 @@ sub saveIdFile {
     # Some sequences do not have UniRef info (e.g. unknown FASTA sequences), so we need to keep
     # track of those. We do that by using this hash and removing elements from it as we process
     # an ID. The remainder are written to the file in the next step.
-    my %seqIds = map { $_ => 1 } $self->getSequenceIds();
+    my %seqIds = map { $_ => undef } $self->getSequenceIds();
     foreach my $id (keys %{ $self->{uniprot} }) {
         $fh->print(join("\t", $id, $self->{uniprot}->{$id}->[0] // "", $self->{uniprot}->{$id}->[1] // ""), "\n");
         delete $seqIds{$id};
@@ -593,7 +616,9 @@ If specified, load the ID mapping, otherwise only metadata is loaded.
 =item C<sequence_version> (optional)
 
 If specified, used instead of sequence version defined at object creation.  One of C<SEQ_UNIPROT>,
-C<SEQ_UNIREF90>, or C<SEQ_UNIREF50> from B<EFI::Sequence::Type>.
+C<SEQ_UNIREF90>, C<SEQ_UNIREF50>, or C<SEQ_AUTO> from B<EFI::Sequence::Type>.  If C<SEQ_AUTO> is
+used, the metadata file is examined for the presence of UniRef attributes and if so, the proper
+sequence version is automatically determined.
 
 =back
 

--- a/lib/EFI/Sequence/Type.pm
+++ b/lib/EFI/Sequence/Type.pm
@@ -12,16 +12,17 @@ use constant SEQ_UNIREF90 => "uniref90";
 use constant SEQ_REPNODE => "repnode";
 use constant SEQ_DOMAIN => "domain";
 use constant SEQ_FULL => "full";
+use constant SEQ_AUTO => "auto";
 
 
-our @EXPORT_OK = qw(is_unknown_sequence get_sequence_version get_sequence_type make_unknown_sequence strip_domain SEQ_UNIPROT SEQ_UNIREF50 SEQ_UNIREF90 SEQ_DOMAIN SEQ_FULL SEQ_REPNODE);
-our %EXPORT_TAGS = (types => ['SEQ_UNIPROT', 'SEQ_UNIREF50', 'SEQ_UNIREF90', 'SEQ_DOMAIN', 'SEQ_FULL', 'SEQ_REPNODE']);
+our @EXPORT_OK = qw(is_unknown_sequence get_sequence_version get_sequence_type make_unknown_sequence strip_domain SEQ_UNIPROT SEQ_UNIREF50 SEQ_UNIREF90 SEQ_DOMAIN SEQ_FULL SEQ_REPNODE SEQ_AUTO);
+our %EXPORT_TAGS = (types => ['SEQ_UNIPROT', 'SEQ_UNIREF50', 'SEQ_UNIREF90', 'SEQ_DOMAIN', 'SEQ_FULL', 'SEQ_REPNODE', 'SEQ_AUTO']);
 Exporter::export_ok_tags('types');
 
 
 sub get_sequence_version {
     my $param = lc (shift // "");
-    if ($param ne SEQ_UNIREF90 and $param ne SEQ_UNIREF50 and $param ne SEQ_REPNODE) {
+    if ($param ne SEQ_UNIREF90 and $param ne SEQ_UNIREF50 and $param ne SEQ_REPNODE and $param ne SEQ_AUTO) {
         return SEQ_UNIPROT;
     }
     return $param;

--- a/lib/pyEFI/pyEFI/plot.py
+++ b/lib/pyEFI/pyEFI/plot.py
@@ -34,16 +34,18 @@ def draw_boxplot(dd, pos, title, xlabel, ylabel, output_filename, output_filetyp
     """
     print(f"Drawing boxplot '{title}'")
     fig, axs = plt.subplots(nrows=1, ncols=1, figsize=(20, 9))
-    axs.bxp(
-        dd,
-        positions=pos,
-        showfliers=False,
-        patch_artist=True,
-        boxprops=dict(facecolor="red", edgecolor="blue", linewidth=0.5),
-        whiskerprops=dict(color="gray", linewidth=0.5, linestyle="dashed"),
-        medianprops=dict(color="blue", linewidth=1),
-        capprops=dict(marker="o", color="gray", markersize=0.005),
-    )
+
+    if dd and pos:
+        axs.bxp(
+            dd,
+            positions=pos,
+            showfliers=False,
+            patch_artist=True,
+            boxprops=dict(facecolor="red", edgecolor="blue", linewidth=0.5),
+            whiskerprops=dict(color="gray", linewidth=0.5, linestyle="dashed"),
+            medianprops=dict(color="blue", linewidth=1),
+            capprops=dict(marker="o", color="gray", markersize=0.005),
+        )
 
     label_and_render_plot(fig, axs, pos, title, xlabel, ylabel, output_filename, output_filetype, dpis)
     plt.close(fig)
@@ -77,7 +79,9 @@ def draw_histogram(xpos, heights, title, xlabel, ylabel, output_filename, output
     """
     print(f"Drawing histogram '{title}'")
     fig, axs = plt.subplots(nrows=1, ncols=1, figsize=(18, 9))
-    axs.bar(x=xpos, height=heights, edgecolor="blue", facecolor="red", linewidth=0.5, width=0.8)
+
+    if len(xpos) > 0 and len(heights) > 0:
+        axs.bar(x=xpos, height=heights, edgecolor="blue", facecolor="red", linewidth=0.5, width=0.8)
 
     label_and_render_plot(fig, axs, xpos, title, xlabel, ylabel, output_filename, output_filetype, dpis)
     plt.close(fig)
@@ -120,31 +124,38 @@ def label_and_render_plot(fig, axs, pos, title, xlabel, ylabel, output_filename,
     axs.set_ylabel(ylabel)
     axs.spines[["right", "top"]].set_visible(False)
 
-    # Set the approx 30 major ticks
-    axs.xaxis.set_major_locator(
-        MaxNLocator(
-            nbins = 29,
-            steps = [1,2,2.5,5,10],
-            integer = True,
-            min_n_ticks = 2
+    if len(pos) > 0:
+        # Set the approx 30 major ticks
+        axs.xaxis.set_major_locator(
+            MaxNLocator(
+                nbins = 29,
+                steps = [1,2,2.5,5,10],
+                integer = True,
+                min_n_ticks = 2
+            )
         )
-    )
 
-    # Get the tick positions to set the labels
-    major_ticks = axs.get_xticks()
-    major_labels = [int(tick_pos) for tick_pos in major_ticks]
-    axs.set_xticks(ticks = major_ticks, labels = major_labels)
-    # Set the minor ticks
-    axs.xaxis.set_minor_locator(AutoMinorLocator())
+        # Get the tick positions to set the labels
+        major_ticks = axs.get_xticks()
+        major_labels = [int(tick_pos) for tick_pos in major_ticks]
+        axs.set_xticks(ticks = major_ticks, labels = major_labels)
+        # Set the minor ticks
+        axs.xaxis.set_minor_locator(AutoMinorLocator())
 
-    # Set the y-axis ticks via the AutoLocator classes
-    axs.yaxis.set_major_locator(AutoLocator())
-    axs.yaxis.set_minor_locator(AutoMinorLocator())
+        # Set the y-axis ticks via the AutoLocator classes
+        axs.yaxis.set_major_locator(AutoLocator())
+        axs.yaxis.set_minor_locator(AutoMinorLocator())
 
-    axs.set_xlim(pos[0] - 1, pos[-1] + 1)
+        axs.set_xlim(pos[0] - 1, pos[-1] + 1)
 
-    # Add grid lines for both axes' major ticks
-    axs.grid(which = "major", axis = "both", color = "xkcd:light grey", linestyle = "--", alpha = 0.5) 
+        # Add grid lines for both axes' major ticks
+        axs.grid(which = "major", axis = "both", color = "xkcd:light grey", linestyle = "--", alpha = 0.5) 
+    else:
+        # Provide default view limits for empty dataset plots
+        axs.set_xlim(0, 1)
+        axs.set_ylim(0, 1)
+        axs.text(0.5, 0.5, "No Data Available", ha='center', va='center', fontsize=14, color='gray')
+
     fig.savefig(f"{output_filename}.{output_filetype}", bbox_inches="tight", dpi=300)
     axs.grid(False)
 

--- a/pipelines/est/subworkflows/import.nf
+++ b/pipelines/est/subworkflows/import.nf
@@ -77,7 +77,7 @@ workflow IMPORT_AND_FILTER {
         user_filter_file = get_user_filter_file()
 
         // Filter on all sequence IDs including UniRef, and including IDs in FASTA files
-        sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]), user_filter_file)
+        sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]), user_filter_file, params.sequence_version)
 
         // Get sunburst data for all sequence IDs, after filtering
         get_sunburst_data(sequence_id_files.accession_table, sequence_id_files.sequence_metadata)

--- a/pipelines/est/visualization/plot_blast_results.py
+++ b/pipelines/est/visualization/plot_blast_results.py
@@ -90,10 +90,18 @@ def main(
     print(f"Removing {len(groups_to_delete)} groups")
     df = delete_outlying_groups(df, groups_to_delete)
 
+    if df.empty:
+        print("Warning: all data groups were filtered out.  Generating empty plots")
+
     # Plot alignment_length
     print("Plotting alignment length")
-    length_dd = df[["al_whislo", "al_q1", "al_med", "al_q3", "al_whishi","_label"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
-    length_xpos = sorted(df["alignment_score"])
+
+    if not df.empty:
+        length_dd = df[["al_whislo", "al_q1", "al_med", "al_q3", "al_whishi","_label"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
+        length_xpos = sorted(df["alignment_score"])
+    else:
+        length_dd, length_xpos = [], []
+
     draw_boxplot(
         length_dd,
         length_xpos,
@@ -107,8 +115,13 @@ def main(
 
     # Percent identical box plot data
     print("Plotting percent identical")
-    pident_dd = df[["pident_whislo", "pident_q1", "pident_med", "pident_q3", "pident_whishi"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
-    pident_xpos = sorted(df["alignment_score"])
+
+    if not df.empty:
+        pident_dd = df[["pident_whislo", "pident_q1", "pident_med", "pident_q3", "pident_whishi"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
+        pident_xpos = sorted(df["alignment_score"])
+    else:
+        pident_dd, pident_xpos = [], []
+
     draw_boxplot(
         pident_dd,
         pident_xpos,
@@ -122,7 +135,12 @@ def main(
 
     # Draw edge length histogram
     print("Extracting histogram data")
-    xpos, heights = df["alignment_score"], df["edge_count"]
+
+    if not df.empty:
+        xpos, heights = df["alignment_score"], df["edge_count"]
+    else:
+        xpos, heights = [], []
+
     draw_histogram(
         xpos,
         heights,

--- a/pipelines/est/visualization/plot_blast_results.py
+++ b/pipelines/est/visualization/plot_blast_results.py
@@ -88,19 +88,19 @@ def main(
     groups_to_delete = compute_outlying_groups(df[["alignment_score", "edge_count"]], min_edges, min_groups)
 
     print(f"Removing {len(groups_to_delete)} groups")
-    df = delete_outlying_groups(df, groups_to_delete)
+    filtered_df = delete_outlying_groups(df, groups_to_delete)
 
-    if df.empty:
-        print("Warning: all data groups were filtered out.  Generating empty plots")
+    # If the filtered frame is not empty, then we use it to plot; otherwise use the original data
+    if not filtered_df.empty:
+        df = filtered_df
+    else:
+        print("Warning: all data groups were filtered out.  Using entire dataset for plots.")
 
     # Plot alignment_length
     print("Plotting alignment length")
 
-    if not df.empty:
-        length_dd = df[["al_whislo", "al_q1", "al_med", "al_q3", "al_whishi","_label"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
-        length_xpos = sorted(df["alignment_score"])
-    else:
-        length_dd, length_xpos = [], []
+    length_dd = df[["al_whislo", "al_q1", "al_med", "al_q3", "al_whishi","_label"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
+    length_xpos = sorted(df["alignment_score"])
 
     draw_boxplot(
         length_dd,
@@ -116,11 +116,8 @@ def main(
     # Percent identical box plot data
     print("Plotting percent identical")
 
-    if not df.empty:
-        pident_dd = df[["pident_whislo", "pident_q1", "pident_med", "pident_q3", "pident_whishi"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
-        pident_xpos = sorted(df["alignment_score"])
-    else:
-        pident_dd, pident_xpos = [], []
+    pident_dd = df[["pident_whislo", "pident_q1", "pident_med", "pident_q3", "pident_whishi"]].rename(columns=lambda x: x.split("_")[1]).to_dict(orient="records")
+    pident_xpos = sorted(df["alignment_score"])
 
     draw_boxplot(
         pident_dd,
@@ -136,10 +133,7 @@ def main(
     # Draw edge length histogram
     print("Extracting histogram data")
 
-    if not df.empty:
-        xpos, heights = df["alignment_score"], df["edge_count"]
-    else:
-        xpos, heights = [], []
+    xpos, heights = df["alignment_score"], df["edge_count"]
 
     draw_histogram(
         xpos,

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -298,7 +298,7 @@ workflow {
 
     // Explicitly specify the IDs that will be passed through, by computing the lengths of the
     // sequences and returning a file containing IDs for all of the sequences that fit the length
-    // criteria.
+    // criteria.  This is necessary due to unknown IDs that come from FASTA jobs.
     explicit_ids_file = (params.min_length != 0 || params.max_length != 65000)
         ? compute_fasta_lengths(input_data.fasta)
         : Channel.value([])

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -303,8 +303,10 @@ workflow {
         ? compute_fasta_lengths(input_data.fasta)
         : Channel.value([])
 
-    // Filter sequences out by length or other criteria (e.g. fragment, taxonomy)
-    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, Channel.value([]))
+    // Filter sequences out by length or other criteria (e.g. fragment, taxonomy).
+    // 'auto' is used as the sequence version so that the code automatically detects what
+    // the type is based on the attributes present in the sequence metadata file.
+    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, Channel.value([]), 'auto')
 
     filtered_fasta = filter_fasta(input_data.fasta, final_ids.master_ids)
 

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -22,6 +22,7 @@ process filter_ids {
         path explicit_ids_file  // manually specify which IDs pass through; this may be empty (e.g. Channel.value([]))
         path user_filter_file   // path to user taxonomy filter file; this may be empty (e.g. Channel.value([]));
                                 //     this is necessary to stage the filter file so it can be read inside this process
+        val sequence_version    // One of the types defined in EFI::Sequence::Type (e.g. uniprot, auto)
     output:
         path 'accession_table.tab', emit: 'accession_table'     // table of all sequence IDs, including UniRef IDs, filtered
         path 'sequence_metadata.tab', emit: 'sequence_metadata' // sequence metdata in metadata format
@@ -36,7 +37,7 @@ process filter_ids {
     perl $projectDir/../shared/import/filter_ids.pl \
         --efi-config ${params.efi_config} \
         --efi-db ${params.efi_db} \
-        --sequence-version ${params.sequence_version} \
+        --sequence-version ${sequence_version} \
         --source-ids-file ${source_ids} \
         --source-meta-file ${source_meta} \
         --source-stats-file ${source_stats} \

--- a/pipelines/shared/nextflow/sequence.nf
+++ b/pipelines/shared/nextflow/sequence.nf
@@ -33,6 +33,8 @@ process filter_ids {
     def xids_file = explicit_ids_file ? "--filter explicit-ids-file=${explicit_ids_file}" : ""
     def filter_args = formatFilterArgs(params.filter)
     def user_filter_arg = user_filter_file ? "--filter user-filter=${user_filter_file}" : ""
+    def min_len_arg = params.min_length != 0 ? "--filter min-seq-length=${params.min_length}" : ""
+    def max_len_arg = params.max_length != 65000 ? "--filter max-seq-length=${params.max_length}" : ""
     """
     perl $projectDir/../shared/import/filter_ids.pl \
         --efi-config ${params.efi_config} \
@@ -47,7 +49,7 @@ process filter_ids {
         --master-ids-file master_ids.tab \
         --stats-file import_stats.json \
         ${filter_args} ${user_filter_arg} \
-        ${xids_file}
+        ${xids_file} ${min_len_arg} ${max_len_arg}
     """
 }
 

--- a/pipelines/taxonomy/taxonomy.nf
+++ b/pipelines/taxonomy/taxonomy.nf
@@ -63,7 +63,7 @@ workflow {
 
     // Filter on all sequence IDs including UniRef, and including IDs in FASTA files.
     // The last parameter is empty (used only for generatessn)
-    sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]), user_filter_file)
+    sequence_id_files = filter_ids(source_data.source_ids, source_data.source_meta, source_data.source_stats, Channel.value([]), user_filter_file, params.sequence_version)
 
     // Get sunburst data for all sequence IDs, after filtering
     sunburst_data = get_sunburst_data(sequence_id_files.accession_table, sequence_id_files.sequence_metadata)

--- a/tests/modules/16c_taxonomy_families_filter_seq_length.sh
+++ b/tests/modules/16c_taxonomy_families_filter_seq_length.sh
@@ -11,6 +11,6 @@ rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
 
-./bin/create_taxonomy_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --filter min_seq_length=10 --filter max_seq_length=150
+./bin/create_taxonomy_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --fasta-db $EFI_FASTA_DB --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE --filter min-seq-length=10 --filter max-seq-length=150
 bash $OUTPUT_DIR/run_nextflow.sh
 

--- a/tests/modules/20a_est_generatessn_fragment_filter.sh
+++ b/tests/modules/20a_est_generatessn_fragment_filter.sh
@@ -10,8 +10,9 @@ OUTPUT_DIR="$TEST_RESULTS_DIR/$self"
 rm -rf $OUTPUT_DIR
 
 family=$(<$EFI_TEST_FAMILY_ID)
+seq_ver=uniref50
 
-./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version uniprot --nextflow-config $CONFIG_FILE
+./bin/create_est_nextflow_params.py family --output-dir $OUTPUT_DIR --efi-config $EFI_CONFIG_FILE --fasta-db $EFI_FASTA_DB --efi-db $EFI_DB_NAME --families $family --sequence-version $seq_ver --nextflow-config $CONFIG_FILE
 bash $OUTPUT_DIR/run_nextflow.sh
 
 ./bin/create_generatessn_nextflow_params.py auto --threshold-min-val 87 --threshold-metric alignment_score --ssn-name testssn --job-name test-ssn --est-output-dir $OUTPUT_DIR --nextflow-config $CONFIG_FILE --efi-config $EFI_CONFIG_FILE --efi-db $EFI_DB_NAME --filter fragments


### PR DESCRIPTION
This PR contains fixes to filtering performed when creating SSNs (i.e. during the generatessn pipeline).  The code now supports automatic determination of sequence type to fix UniRef metadata synchronization in accession table and sequence metadata files - necessary for SSN filtering.  Length filtering now works properly and is applied in two steps: A) the `compute_fasta_length` process to come up with a list of IDs--both unknown ZZZ and UniProt--that are within the specified length filter range, and B) the normal `min-seq-length` and `max-seq-length` filters passed to `filter_ids.pl`.  Since the job manager passes these parameters as `--min-length` and `--max-length` rather than `--filter min-seq-length...`, a minor update converts these parameters into `--filter` arguments in the process block.  Previously, the taxonomy min/max length filter was not being applied due to the `--min-length` and `--max-length` argument usage, and this PR contains the fix that will work for taxonomy in addition to generatessn.  Finally, if the computed dataset is too small, the plot generation process was failing due to not having data.  This PR also contains a fix that creates empty graphs if there is no data (rather than failing).

When deploying these changes, the Python venv will need to be updated with pip in order for the plot changes to take effect.