### PR TITLE
Remove length filtering from annotations retrieval

### DIFF
--- a/pipelines/generatessn/annotations/get_annotations.pl
+++ b/pipelines/generatessn/annotations/get_annotations.pl
@@ -18,14 +18,12 @@ use EFI::Sequence::Collection qw(unique_attribute_values);
 use EFI::Sequence::Type qw(is_unknown_sequence :types);
 
 
-my ($annoOut, $metaFileIn, $configFile, $dbName, $minLen, $maxLen, $annoSpecFile, $idListFile);
+my ($annoOut, $metaFileIn, $configFile, $dbName, $annoSpecFile, $idListFile);
 my $result = GetOptions(
     "ssn-anno-out=s"        => \$annoOut,
     "seq-meta-in=s"         => \$metaFileIn,
     "config=s"              => \$configFile,
     "db-name=s"             => \$dbName,
-    "min-len=i"             => \$minLen,
-    "max-len=i"             => \$maxLen,
     "anno-spec-file=s"      => \$annoSpecFile,      # if this is specified we only write out the attributes listed in the file
     "filter-id-list=s"      => \$idListFile,
 );
@@ -48,10 +46,6 @@ if (not $dbh) {
 }
 
 
-
-
-$minLen = 0 if not $minLen or $minLen =~ m/\D/;
-$maxLen = 0 if not $maxLen or $maxLen =~ m/\D/;
 
 
 my %idTypes;
@@ -84,7 +78,6 @@ if (grep { $_ eq FIELD_UNIREF90_IDS } @{ $metaAttrs }) {
 }
 
 
-my $unirefLenFiltWhere = getUnirefLenFiltWhere();
 my $annoSpec = readAnnoSpec($annoSpecFile);
 
 
@@ -227,17 +220,6 @@ sub formatAnnoData {
 }
 
 
-sub getUnirefLenFiltWhere {
-    my $sqlLenField = FIELD_SEQ_LEN_KEY;
-    if ($minLen) {
-        $unirefLenFiltWhere .= "A.$sqlLenField >= $minLen";
-    }
-    if ($maxLen) {
-        $unirefLenFiltWhere .= "A.$sqlLenField <= $maxLen";
-    }
-}
-
-
 #
 # getNcbiIds
 #
@@ -348,7 +330,7 @@ sub getUnirefQuerySql {
     my @allIds = ref($clusterIds) eq "ARRAY" ? @$clusterIds : $clusterIds;
     my @idList = grep(!m/^$accession$/, @allIds); #remove main accession ID
     while (my @chunk = splice(@idList, 0, 200)) {
-        my $sql = $anno->build_query_string(\@chunk, $unirefLenFiltWhere);
+        my $sql = $anno->build_query_string(\@chunk);
         push @sql, $sql;
     }
 

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -95,8 +95,6 @@ process get_annotations {
     """
     perl $projectDir/annotations/get_annotations.pl \
         --ssn-anno-out ssn_metadata.tab \
-        --min-len ${params.min_length} \
-        --max-len ${params.max_length} \
         --seq-meta-in $filtered_seq_meta_file \
         --config ${params.efi_config} \
         --db-name ${params.efi_db}

--- a/pipelines/generatessn/generatessn.nf
+++ b/pipelines/generatessn/generatessn.nf
@@ -1,7 +1,7 @@
 
 include { COMPUTE_COLOR_CLUSTER_WORKFLOW } from "../shared/nextflow/color_workflow.nf"
 include { color_ssn } from "../shared/nextflow/color_xgmml.nf"
-include { filter_ids } from "../shared/nextflow/sequence.nf"
+include { filter_ids; get_user_filter_file } from "../shared/nextflow/sequence.nf"
 include { prepareJobName; prepareSsnFilename; merge_stats } from "../shared/nextflow/util.nf"
 
 process import_data {
@@ -301,10 +301,12 @@ workflow {
         ? compute_fasta_lengths(input_data.fasta)
         : Channel.value([])
 
+    user_filter_file = get_user_filter_file()
+
     // Filter sequences out by length or other criteria (e.g. fragment, taxonomy).
     // 'auto' is used as the sequence version so that the code automatically detects what
     // the type is based on the attributes present in the sequence metadata file.
-    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, Channel.value([]), 'auto')
+    final_ids = filter_ids(input_data.source_ids, input_data.seq_meta_file, input_data.stats, explicit_ids_file, user_filter_file, 'auto')
 
     filtered_fasta = filter_fasta(input_data.fasta, final_ids.master_ids)
 


### PR DESCRIPTION
This PR removes length filtering that was performed during annotations retrieval.  This is now properly handled in the `filter_ids` process block.